### PR TITLE
change the log level of getSubjectAndId to debug instead of info.

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -108,7 +108,7 @@ object SchemaManager {
     * It will return None if the Schema Registry client is not configured.
     */
   def getBySubjectAndId(subject: String, id: Int): Option[Schema] = {
-    logger.info(s"Trying to get schema for subject '$subject' and id '$id'")
+    logger.debug(s"Trying to get schema for subject '$subject' and id '$id'")
     if (isSchemaRegistryConfigured) {
       try {
         Some(schemaRegistryClient.getBySubjectAndId(subject, id))


### PR DESCRIPTION
The log message for getSubjectAndId is displayed per record and this slows down the process when you are handling 1M records per second.

Proposing to change this log message to debug instead of info.