### PR TITLE
allowing schema retrieval and enforcement based on version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>za.co.absa</groupId>
 	<artifactId>abris_2.11</artifactId>
-	<version>2.2.2</version>
+	<version>2.2.3-SNAPSHOT</version>
 	<name>abris</name>
 	<description>Provides seamless integration between Avro and Spark Structured APIs.</description>
 	<url>https://github.com/AbsaOSS/ABRiS</url>

--- a/src/main/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtils.scala
+++ b/src/main/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtils.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.avro.parsing.utils
 
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata
 import org.apache.avro.Schema
 import org.slf4j.LoggerFactory
 import za.co.absa.abris.avro.read.confluent.SchemaManager
@@ -48,6 +49,10 @@ object AvroSchemaUtils {
 
   def load(schemaRegistryConf: Map[String,String]): Schema = {
     SchemaLoader.loadFromSchemaRegistry(schemaRegistryConf)
+  }
+
+  def load(schemaVersion: Int, schemaRegistryConf: Map[String,String]): SchemaMetadata = {
+    SchemaLoader.loadFromSchemaRegistry(schemaVersion, schemaRegistryConf)
   }
 
   def loadForKeyAndValue(schemaRegistryConf: Map[String,String]): (Schema,Schema) = {

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.abris.avro.read.confluent
 
-import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
+import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaMetadata, SchemaRegistryClient}
 import io.confluent.kafka.serializers.{AbstractKafkaAvroSerDeConfig, KafkaAvroDeserializerConfig}
 import org.apache.avro.Schema
 import org.apache.kafka.common.config.ConfigException
@@ -112,6 +112,25 @@ object SchemaManager {
     if (isSchemaRegistryConfigured) {
       try {
         Some(schemaRegistryClient.getBySubjectAndId(subject, id))
+      }
+      catch {
+        case e: Exception =>
+          e.printStackTrace()
+          None
+      }
+    }
+    else None
+  }
+
+  /**
+    * Retrieves an Avro [[SchemaMetadata]] instance from a given subject and stored with a given version.
+    * It will return None if the Schema Registry client is not configured.
+    */
+  def getBySubjectAndVersion(subject: String, version: Int): Option[SchemaMetadata] = {
+    logger.debug(s"Trying to get schema for subject '$subject' and version '$version'")
+    if (isSchemaRegistryConfigured) {
+      try {
+        Some(schemaRegistryClient.getSchemaMetadata(subject, version))
       }
       catch {
         case e: Exception =>


### PR DESCRIPTION
First of all just want to say great job your library is really very very useful!!
The code additions here are to allow a user to provide a topic and the version of the schema of the topic that they want to enforce on their DataFrame before they push to Kafka. The schema is then retrieved from the schema registry and enforced. If you want me add any further functions for Confluent avro for both key and value or anything else let me know :-) 