### PR TITLE
Allow passing basic auth credentials source.

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -49,6 +49,9 @@ object SchemaManager {
   val PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY      = "schema.name"
   val PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY = "schema.namespace"
 
+  val PARAM_SCHEMA_REGISTRY_BASIC_AUTH_SOURCE = "basic.auth.credentials.source"
+  val PARAM_SCHEMA_REGISTRY_BASIC_AUTH_USER_INFO = "schema.registry.basic.auth.user.info"
+
   object SchemaStorageNamingStrategies extends Enumeration {
     val TOPIC_NAME        = "topic.name"
     val RECORD_NAME       = "record.name"
@@ -166,7 +169,8 @@ object SchemaManager {
       val maxSchemaObject = config.getMaxSchemasPerSubject
 
       if (null == schemaRegistryClient) {
-        schemaRegistryClient = new CachedSchemaRegistryClient(urls, maxSchemaObject)
+        val authConfig = config.originalsWithPrefix("").asScala filterKeys Set(PARAM_SCHEMA_REGISTRY_BASIC_AUTH_SOURCE)
+        schemaRegistryClient = new CachedSchemaRegistryClient(urls, maxSchemaObject, authConfig.asJava)
       }
     } catch {
       case e: io.confluent.common.config.ConfigException => throw new ConfigException(e.getMessage)

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerSpec.scala
@@ -131,4 +131,13 @@ class SchemaManagerSpec extends FlatSpec with BeforeAndAfter {
     assertThrows[IllegalArgumentException] {SchemaManager.configureSchemaRegistry(config1)}
     assertThrows[ConfigException] {SchemaManager.configureSchemaRegistry(config2)}
   }
+
+  it should "allow setting basic auth user info if provided" in {
+    val config = Map(
+      SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "http://schema-registry.url",
+      SchemaManager.PARAM_SCHEMA_REGISTRY_BASIC_AUTH_SOURCE -> "URL"
+    )
+
+    SchemaManager.configureSchemaRegistry(config)
+  }
 }


### PR DESCRIPTION
We are using aiven.io for hosting schema registry, which uses basic auth. This PR adds a parameter for `basic.auth.credentials.source` and passes it to the CachedSchemaRegistry.

Ex:
```scala
    val schemaRegistryConf = Map(
      SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "https://user:password@schema.url",
      SchemaManager.PARAM_SCHEMA_REGISTRY_BASIC_AUTH_SOURCE -> "URL"
    )

...
```