### PR TITLE
fixing bug where schema cannot be resolved from union based on datum

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/write/ScalaCustomSpecificData.scala
+++ b/src/main/scala/za/co/absa/abris/avro/write/ScalaCustomSpecificData.scala
@@ -16,10 +16,10 @@
 
 package za.co.absa.abris.avro.write
 
-import org.apache.avro.generic.IndexedRecord
-import org.apache.spark.sql.catalyst.expressions.{GenericRow, Rand}
-import org.apache.avro.{Schema, UnresolvedUnionException}
 import org.apache.avro.generic.GenericData.Record
+import org.apache.avro.generic.IndexedRecord
+import org.apache.avro.{Schema, UnresolvedUnionException}
+import org.apache.spark.sql.catalyst.expressions.GenericRow
 
 import scala.util.Try
 

--- a/src/main/scala/za/co/absa/abris/avro/write/ScalaCustomSpecificData.scala
+++ b/src/main/scala/za/co/absa/abris/avro/write/ScalaCustomSpecificData.scala
@@ -17,7 +17,12 @@
 package za.co.absa.abris.avro.write
 
 import org.apache.avro.generic.IndexedRecord
-import org.apache.spark.sql.catalyst.expressions.GenericRow
+import org.apache.spark.sql.catalyst.expressions.{GenericRow, Rand}
+import org.apache.avro.{Schema, UnresolvedUnionException}
+import org.apache.avro.generic.GenericData.Record
+
+import scala.util.Try
+
 
 object ScalaCustomSpecificData {
   private val INSTANCE = new ScalaCustomSpecificData()
@@ -37,5 +42,22 @@ class ScalaCustomSpecificData extends za.co.absa.abris.avro.format.ScalaSpecific
     catch {
       case _: Throwable => record.asInstanceOf[GenericRow].get(position).asInstanceOf[Object] 
     }
-  }    
+  }
+
+  /**
+    * This is a hack. When a Record datum is created from a dataframe its schema namespace is defined by the location
+    * of the attribute in the dataframe schema as opposed to the avro schema that is to be imposed. This means when the
+    * logic tries to resolve the namespace of the datum (record) from the given types in the union it cannot find it.
+    * The below logic works by if all else fails trying to match the datum schema name with any of the union type names
+    * and if found returning that.
+    * @param union schema
+    * @param datum data
+    */
+  override def resolveUnion(union: Schema, datum: Object): Int = {
+    Try(super.resolveUnion(union, datum)).getOrElse {
+      val name = datum.asInstanceOf[Record].getSchema.getName.toLowerCase
+      val maybeIndex = Range(0, union.getTypes.size()).find(x => name.equals(union.getTypes.get(x).getName.toLowerCase))
+      maybeIndex.getOrElse(throw new UnresolvedUnionException(union, datum))
+    }
+  }
 }


### PR DESCRIPTION
In the `resolveUnion` function the avro lib tries to derive the index of the nested Record schema within the union based on the namespace defined in the data object (`datum`). As this namespace defines the path of the attribute within the dataframe the lib cannot match the namespace with those defined in the union and therefore throws an exception. The override function that has been defined as part of this pull requests attempts to use the original 'resolveUnion` function and if the exception is thrown tries to match the schema based on the last part of the datum namespace.