### PR TITLE
improve performance

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -68,7 +68,7 @@ object SchemaManager extends Logging {
 
     if (adapter.validate(schema)) {
       val subjectName = adapter.subjectName(topic, isKey, schema)
-      logInfo(s"Subject name resolved to: $subjectName")
+      logDebug(s"Subject name resolved to: $subjectName")
       subjectName
     }
     else {
@@ -128,7 +128,7 @@ object SchemaManager extends Logging {
   }
 
   def getById(id: Int): Schema = {
-    logInfo(s"Trying to get schema for id '$id'")
+    logDebug(s"Trying to get schema for id '$id'")
     throwIfClientNotConfigured()
 
     Try(schemaRegistryClient.getById(id)) match {
@@ -141,7 +141,7 @@ object SchemaManager extends Logging {
     * Retrieves the id corresponding to the latest schema available in Schema Registry.
     */
   def getLatestVersionId(subject: String): Int = {
-    logInfo(s"Trying to get latest schema version id for subject '$subject'")
+    logDebug(s"Trying to get latest schema version id for subject '$subject'")
     throwIfClientNotConfigured()
 
     Try(schemaRegistryClient.getLatestSchemaMetadata(subject).getId) match {

--- a/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
+++ b/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
@@ -108,4 +108,9 @@ object SchemaLoader {
       paramId.toInt
     }
   }
+
+  def loadById(id: Int, params: Map[String,String]): Schema = {
+    configureSchemaManager(params)
+    SchemaManager.getById(id)
+  }
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -30,6 +30,7 @@ import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression,
 import org.apache.spark.sql.types.{BinaryType, DataType}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.{ConfluentConstants, SchemaManager}
+import za.co.absa.abris.avro.schemas.SchemaLoader
 
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -106,8 +107,7 @@ case class AvroDataToCatalyst(
   }
 
   private def getWriterSchema(id: Int): Schema = {
-    SchemaManager.configureSchemaRegistry(schemaRegistryConf.get)
-    Try(SchemaManager.getById(id)) match {
+    Try(SchemaLoader.loadById(id, schemaRegistryConf.get)) match {
       case Success(schema)  => schema
       case Failure(e)       => throw new RuntimeException("Not able to load writer schema", e)
     }

--- a/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
@@ -34,14 +34,14 @@ case class CatalystDataToAvro(
 
   override def dataType: DataType = BinaryType
 
+  private lazy val schemaId = schemaRegistryConf.flatMap(conf =>
+    registerSchema(schemaProvider.wrappedSchema(child), conf, confluentCompliant))
+
   @transient private lazy val serializer: AvroSerializer =
     new AvroSerializer(child.dataType, schemaProvider.originalSchema(child), child.nullable)
 
   override def nullSafeEval(input: Any): Any = {
     val avroData = serializer.serialize(input)
-
-    val schemaId = schemaRegistryConf.flatMap(conf =>
-      registerSchema(schemaProvider.wrappedSchema(child), conf, confluentCompliant))
 
     val record : IndexedRecord = avroData match {
       case ad: IndexedRecord => ad

--- a/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroReader.scala
+++ b/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroReader.scala
@@ -69,12 +69,11 @@ object ConfluentKafkaAvroReader {
     val schemaRegistryConfig = properties.getSchemaRegistryConfigurations(PARAM_OPTION_SUBSCRIBE)
 
     if (properties.getProperty(PARAM_EXAMPLE_SHOULD_USE_SCHEMA_REGISTRY).toBoolean) {
-      dataFrame.select(from_confluent_avro(col("value"), schemaRegistryConfig) as 'data).select("data.*")
+      dataFrame.select(from_confluent_avro(col("value"), schemaRegistryConfig) as 'data)
     } else {
       val source = scala.io.Source.fromFile(properties.getProperty(PARAM_PAYLOAD_AVRO_SCHEMA))
       val schemaString = try source.mkString finally source.close()
       dataFrame.select(from_confluent_avro(col("value"), schemaString, schemaRegistryConfig) as 'data)
-        .select("data.*")
     }
   }
 }

--- a/src/main/scala/za/co/absa/abris/examples/KafkaAvroReader.scala
+++ b/src/main/scala/za/co/absa/abris/examples/KafkaAvroReader.scala
@@ -66,12 +66,12 @@ object KafkaAvroReader {
 
     if (props.getProperty(PARAM_EXAMPLE_SHOULD_USE_SCHEMA_REGISTRY).toBoolean) {
       val schemaRegistryConfig = props.getSchemaRegistryConfigurations(PARAM_OPTION_SUBSCRIBE)
-      dataFrame.select(from_avro(col("value"), schemaRegistryConfig) as 'data).select("data.*")
+      dataFrame.select(from_avro(col("value"), schemaRegistryConfig) as 'data)
     }
     else {
       val source = scala.io.Source.fromFile(props.getProperty(PARAM_PAYLOAD_AVRO_SCHEMA))
       val schemaString = try source.mkString finally source.close()
-      dataFrame.select(from_avro(col("value"), schemaString) as 'data).select("data.*")
+      dataFrame.select(from_avro(col("value"), schemaString) as 'data)
     }
   }
 }

--- a/src/test/resources/AvroReadingExample.properties
+++ b/src/test/resources/AvroReadingExample.properties
@@ -30,7 +30,7 @@ key.schema.id=latest
 example.should.use.schema.registry=true
 
 # key.schema.naming.strategy=record.name
-value.schema.naming.strategy=topic.record.name
+value.schema.naming.strategy=topic.name
 
 schema.name=native_complete
 schema.namespace=all-types.test


### PR DESCRIPTION
- avoid unnecessary schema registration calls
- more consistent by id schema lookup
- schema manager warnings shouldn't appear when ABRiS is working as it should.