### PR TITLE
Add schema version parameter to read/write avro schema registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ val schemaRegistryConfig = Map(
   SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC        -> "topic_name",
   SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY -> SchemaManager.SchemaStorageNamingStrategies.{TOPIC_NAME, RECORD_NAME, TOPIC_RECORD_NAME}, // choose a subject name strategy
   SchemaManager.PARAM_VALUE_SCHEMA_ID              -> "current_schema_id" // set to "latest" if you want the latest schema version to used  
+  SchemaManager.PARAM_VALUE_SCHEMA_VERSION         -> "current_schema_version" // set to "latest" if you want the latest schema version to used
 )
 ```
 Depending on the selected naming strategy you may also need to provide ```SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY``` and ```SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY```
@@ -189,7 +190,9 @@ val schemaRegistryConfig = Map(
   SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC                -> "topic_name",
   SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY         -> SchemaManager.SchemaStorageNamingStrategies.TOPIC_RECORD_NAME,
   SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "schema_name",
-  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "schema_namespace"
+  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "schema_namespace",
+  SchemaManager.PARAM_VALUE_SCHEMA_ID                      -> "current_schema_id", // (optional) set to "latest" if you want the latest schema version to used
+  SchemaManager.PARAM_VALUE_SCHEMA_VERSION                 -> "current_schema_version" // (optional) set to "latest" if you want the latest schema version to used
 )
 ```
 In this example the ```TOPIC_RECORD_NAME``` naming strategy is used, therefore we need to provide topic, name and namespace.

--- a/src/main/scala/za/co/absa/abris/avro/functions.scala
+++ b/src/main/scala/za/co/absa/abris/avro/functions.scala
@@ -118,7 +118,7 @@ object functions {
     val namespace = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
 
     new Column(sql.CatalystDataToAvro(
-      data.expr, SchemaProvider(name, namespace), Some(schemaRegistryConf), confluentCompliant = false))
+      data.expr, SchemaProvider(name, namespace, schemaRegistryConf), Some(schemaRegistryConf), confluentCompliant = false))
   }
 
   /**
@@ -147,7 +147,7 @@ object functions {
     val namespace = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
 
     new Column(sql.CatalystDataToAvro(
-      data.expr, SchemaProvider(name, namespace), Some(schemaRegistryConf), confluentCompliant = true))
+      data.expr, SchemaProvider(name, namespace, schemaRegistryConf), Some(schemaRegistryConf), confluentCompliant = true))
   }
 
   /**

--- a/src/main/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtils.scala
+++ b/src/main/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtils.scala
@@ -31,12 +31,6 @@ object AvroSchemaUtils {
 
   private val logger = LoggerFactory.getLogger(AvroSchemaUtils.getClass)
 
-  private def configureSchemaManager(schemaRegistryConf: Map[String,String]): Unit = {
-    if (!SchemaManager.isSchemaRegistryConfigured) {
-      SchemaManager.configureSchemaRegistry(schemaRegistryConf)
-    }
-  }
-
   /**
    * Parses a plain Avro schema into an org.apache.avro.Schema implementation.
    */
@@ -95,7 +89,7 @@ object AvroSchemaUtils {
     schemaRegistryConf: Map[String,String],
     isKey: Boolean): Option[Int] = {
 
-    configureSchemaManager(schemaRegistryConf)
+    SchemaManager.configure(schemaRegistryConf)
 
     val subject = SchemaManager.getSubjectName(topic, isKey, schema, schemaRegistryConf)
 

--- a/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
+++ b/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
@@ -41,7 +41,7 @@ object SchemaLoader {
   }
 
   def loadFromSchemaRegistryValue(params: Map[String,String]): Schema = {
-    configureSchemaManager(params)
+    SchemaManager.configure(params)
 
     val topic = params(SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC)
     val specifiedSchemaId = params(SchemaManager.PARAM_VALUE_SCHEMA_ID)
@@ -50,7 +50,7 @@ object SchemaLoader {
   }
 
   def loadFromSchemaRegistryKey(params: Map[String,String]): Schema = {
-    configureSchemaManager(params)
+    SchemaManager.configure(params)
 
     val topic = params(SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC)
     val specifiedSchemaId = params(SchemaManager.PARAM_KEY_SCHEMA_ID)
@@ -59,7 +59,7 @@ object SchemaLoader {
   }
 
   def loadFromSchemaRegistry(version: Int, params: Map[String,String]): SchemaMetadata = {
-    configureSchemaManager(params)
+    SchemaManager.configure(params)
 
     val topic = params(SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC)
 
@@ -94,12 +94,6 @@ object SchemaLoader {
     SchemaManager.getBySubjectAndVersion(subject, version)
   }
 
-  private def configureSchemaManager(params: Map[String,String]): Unit = {
-    if (!SchemaManager.isSchemaRegistryConfigured) {
-      SchemaManager.configureSchemaRegistry(params)
-    }
-  }
-
   private def getSchemaId(paramId: String, subject: String): Int = {
     if (paramId == SchemaManager.PARAM_SCHEMA_ID_LATEST_NAME) {
       SchemaManager.getLatestVersionId(subject)
@@ -110,7 +104,7 @@ object SchemaLoader {
   }
 
   def loadById(id: Int, params: Map[String,String]): Schema = {
-    configureSchemaManager(params)
+    SchemaManager.configure(params)
     SchemaManager.getById(id)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.catalyst.expressions.{Expression, UnaryExpression}
 import org.apache.spark.sql.types.{BinaryType, DataType}
 import za.co.absa.abris.avro.format.SparkAvroConversions
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.avro.read.confluent.SchemaManager
 
 case class CatalystDataToAvro(
    child: Expression,
@@ -72,8 +73,10 @@ case class CatalystDataToAvro(
       schema: Schema,
       registryConfig: Map[String,String],
       prependSchemaId: Boolean): Option[Int] = {
-
-    val schemaId = AvroSchemaUtils.registerSchema(schema, registryConfig)
+    var schemaId = SchemaManager.getIdFromConfig(registryConfig)
+    if (schemaId.isEmpty) {
+      schemaId = AvroSchemaUtils.registerSchema(schema, registryConfig)
+    }
 
     if (prependSchemaId) schemaId else None
   }


### PR DESCRIPTION
It's not uncommon to use the schema version number to retrieve an schema from the Schema Registry instead of the id so this PR adds support for that to read from avro format.

Also this PR enables the previous functionality (define the schema by the version or the id) to the functions that serialize the data to avro format. There are cases where producers are not responsible for registering and maintaining the schema, so it makes sense that you can pass the version or the id of the schema you want to use as a parameter and avoid registering a new schema to the Schema Registry.

In this case I prioritized the version number over the ID, but I guess that could be changed.