### PR TITLE
allowing key and value to use record and topic record strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ val commonRegistryConfig = Map(
 val keyRegistryConfig = commonRegistryConfig ++ Map(
   SchemaManager.PARAM_KEY_SCHEMA_NAMING_STRATEGY -> "topic.record.name",
   SchemaManager.PARAM_KEY_SCHEMA_ID -> "latest",
-  SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "foo",
-  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "com.bar"
+  SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "foo",
+  SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "com.bar"
 )
 
 val valueRegistryConfig = commonRegistryConfig ++ Map(
@@ -186,13 +186,13 @@ If you provide the Avro schema as a second argument, ABRiS will use it to conver
 First we need to provide the Schema Registry configuration:
 ```scala
 val schemaRegistryConfig = Map(
-  SchemaManager.PARAM_SCHEMA_REGISTRY_URL                  -> "url_to_schema_registry",
-  SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC                -> "topic_name",
-  SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY         -> SchemaManager.SchemaStorageNamingStrategies.TOPIC_RECORD_NAME,
-  SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "schema_name",
-  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "schema_namespace",
-  SchemaManager.PARAM_VALUE_SCHEMA_ID                      -> "current_schema_id", // (optional) set to "latest" if you want the latest schema version to used
-  SchemaManager.PARAM_VALUE_SCHEMA_VERSION                 -> "current_schema_version" // (optional) set to "latest" if you want the latest schema version to used
+  SchemaManager.PARAM_SCHEMA_REGISTRY_URL                        -> "url_to_schema_registry",
+  SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC                      -> "topic_name",
+  SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY               -> SchemaManager.SchemaStorageNamingStrategies.TOPIC_RECORD_NAME,
+  SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "schema_name",
+  SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "schema_namespace",
+  SchemaManager.PARAM_VALUE_SCHEMA_ID                            -> "current_schema_id", // (optional) set to "latest" if you want the latest schema version to used
+  SchemaManager.PARAM_VALUE_SCHEMA_VERSION                       -> "current_schema_version" // (optional) set to "latest" if you want the latest schema version to used
 )
 ```
 In this example the ```TOPIC_RECORD_NAME``` naming strategy is used, therefore we need to provide topic, name and namespace.
@@ -251,8 +251,8 @@ As in the reading example, for writing you also have to specify the naming strat
 val commonRegistryConfig = Map(
   SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> "example_topic",
   SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "http://localhost:8081",
-  SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "foo",
-  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "com.bar"
+  SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "foo",
+  SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "com.bar"
 )
 
 val keyRegistryConfig = commonRegistryConfig +
@@ -282,9 +282,7 @@ To make use of those, all that is required is to add them to the settings map as
 ```scala
 val commonRegistryConfig = Map(
   SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> "example_topic",
-  SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "http://localhost:8081",
-  SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "foo",
-  SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "com.bar"
+  SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "http://localhost:8081"
 )
 
 val valueRegistryConfig = commonRegistryConfig +
@@ -335,8 +333,10 @@ This library also provides utility methods for registering schemas with topics i
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL                  -> "url_to_schema_registry",
       SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY         -> SchemaManager.SchemaStorageNamingStrategies.{TOPIC_NAME, RECORD_NAME, TOPIC_RECORD_NAME}, // if you are retrieving value schema
       SchemaManager.PARAM_KEY_SCHEMA_NAMING_STRATEGY           -> SchemaManager.SchemaStorageNamingStrategies.{TOPIC_NAME, RECORD_NAME, TOPIC_RECORD_NAME}, // if your are retrieving key schema
-      SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "schema_name", // if you're using RecordName or TopicRecordName strategies
-      SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "schema_namespace" // if you're using RecordName or TopicRecordName strategies
+      SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "key_schema_name", // if you're using RecordName or TopicRecordName strategies for key
+      SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "key_schema_namespace", // if you're using RecordName or TopicRecordName strategies for key
+      SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY      -> "value_schema_name", // if you're using RecordName or TopicRecordName strategies for value
+      SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "value_schema_namespace" // if you're using RecordName or TopicRecordName strategies for value
     )
     SchemaManager.configureSchemaRegistry(schemaRegistryConfs)
 

--- a/src/main/scala/za/co/absa/abris/avro/functions.scala
+++ b/src/main/scala/za/co/absa/abris/avro/functions.scala
@@ -114,8 +114,8 @@ object functions {
    * @param schemaRegistryConf schema registry configuration
    */
   def to_avro(data: Column, schemaRegistryConf: Map[String,String]): Column = {
-    val name = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY)
-    val namespace = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+
+    val (name, namespace) = SchemaManager.getMaybeSchemaNameAndNameSpace(schemaRegistryConf, isKey(data))
 
     new Column(sql.CatalystDataToAvro(
       data.expr, SchemaProvider(name, namespace, schemaRegistryConf), Some(schemaRegistryConf), confluentCompliant = false))
@@ -143,8 +143,7 @@ object functions {
    */
   def to_confluent_avro(data: Column, schemaRegistryConf: Map[String,String]): Column = {
 
-    val name = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY)
-    val namespace = schemaRegistryConf.get(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+    val (name, namespace) = SchemaManager.getMaybeSchemaNameAndNameSpace(schemaRegistryConf, isKey(data))
 
     new Column(sql.CatalystDataToAvro(
       data.expr, SchemaProvider(name, namespace, schemaRegistryConf), Some(schemaRegistryConf), confluentCompliant = true))
@@ -161,6 +160,10 @@ object functions {
 
     new Column(sql.CatalystDataToAvro(
       data.expr, SchemaProvider(jsonFormatSchema), Some(schemaRegistryConf), confluentCompliant = true))
+  }
+
+  private def isKey(col: Column): Boolean = {
+    col.toString().toLowerCase == "key"
   }
 
   // scalastyle:on: method.name

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -105,8 +105,8 @@ object SchemaManager extends Logging {
   }
 
   def getSchemaNameAndNameSpace(params: Map[String, String], isKey: Boolean): (String,String) = {
-val (maybeName, maybeNamespace) = getMaybeSchemaNameAndNameSpace(params, isKey)
-(maybeName.getOrElse(null), maybeNamespace.getOrElse(null))
+    val (maybeName, maybeNamespace) = getMaybeSchemaNameAndNameSpace(params, isKey)
+    (maybeName.getOrElse(null), maybeNamespace.getOrElse(null))
   }
 
   def getMaybeSchemaNameAndNameSpace(params: Map[String, String], isKey: Boolean): (Option[String],Option[String]) = {

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -50,8 +50,11 @@ object SchemaManager extends Logging {
   val PARAM_KEY_SCHEMA_NAMING_STRATEGY   = "key.schema.naming.strategy"
   val PARAM_VALUE_SCHEMA_NAMING_STRATEGY = "value.schema.naming.strategy"
 
-  val PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY      = "schema.name"
-  val PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY = "schema.namespace"
+  val PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY      = "key.schema.name"
+  val PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY = "key.schema.namespace"
+
+  val PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY      = "value.schema.name"
+  val PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY = "value.schema.namespace"
 
   object SchemaStorageNamingStrategies extends Enumeration {
     val TOPIC_NAME        = "topic.name"
@@ -91,10 +94,38 @@ object SchemaManager extends Logging {
 
   def getSubjectName(params: Map[String, String]): String = {
     val topic = params(PARAM_SCHEMA_REGISTRY_TOPIC)
-    val schemaName = params.getOrElse(PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY, null)
-    val schemaNamespace = params.getOrElse(PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY, null)
+
+    val (schemaName, schemaNamespace) = getSchemaNameAndNameSpace(params)
 
     getSubjectName(topic, isKey(params), (schemaName, schemaNamespace), params)
+  }
+
+  def getSchemaNameAndNameSpace(params: Map[String, String]): (String,String) = {
+    getSchemaNameAndNameSpace(params, isKey(params))
+  }
+
+  def getSchemaNameAndNameSpace(params: Map[String, String], isKey: Boolean): (String,String) = {
+    if (isKey) {
+      val keySchemaName = params.getOrElse(PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY, null)
+      val keySchemaNamespace = params.getOrElse(PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY, null)
+      (keySchemaName, keySchemaNamespace)
+    } else {
+      val valueSchemaName = params.getOrElse(PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY, null)
+      val valueSchemaNamespace = params.getOrElse(PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY, null)
+      (valueSchemaName, valueSchemaNamespace)
+    }
+  }
+
+  def getMaybeSchemaNameAndNameSpace(params: Map[String, String], isKey: Boolean): (Option[String],Option[String]) = {
+    if (isKey) {
+      val keySchemaName = params.get(PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY)
+      val keySchemaNamespace = params.get(PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+      (keySchemaName, keySchemaNamespace)
+    } else {
+      val valueSchemaName = params.get(PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY)
+      val valueSchemaNamespace = params.get(PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+      (valueSchemaName, valueSchemaNamespace)
+    }
   }
 
   private def getSubjectNamingStrategyAdapter(isKey: Boolean, params: Map[String,String]) = {

--- a/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
+++ b/src/main/scala/za/co/absa/abris/avro/schemas/SchemaLoader.scala
@@ -72,8 +72,7 @@ object SchemaLoader {
     isKey: Boolean,
     params: Map[String,String]): Schema = {
 
-    val schemaName = params.getOrElse(SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY, null)
-    val schemaNamespace = params.getOrElse(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY, null)
+    val (schemaName, schemaNamespace) = SchemaManager.getSchemaNameAndNameSpace(params, isKey)
 
     val subject = SchemaManager.getSubjectName(topic, isKey, (schemaName, schemaNamespace), params)
 
@@ -87,8 +86,7 @@ object SchemaLoader {
     params: Map[String,String],
     version: Int): SchemaMetadata = {
 
-    val schemaName = params.getOrElse(SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY, null)
-    val schemaNamespace = params.getOrElse(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY, null)
+    val (schemaName, schemaNamespace) = SchemaManager.getSchemaNameAndNameSpace(params, isKey)
 
     val subject = SchemaManager.getSubjectName(topic, isKey, (schemaName, schemaNamespace), params)
     SchemaManager.getBySubjectAndVersion(subject, version)

--- a/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroReaderWithKey.scala
+++ b/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroReaderWithKey.scala
@@ -33,6 +33,12 @@ object ConfluentKafkaAvroReaderWithKey {
   private val PARAM_OPTION_SUBSCRIBE = "option.subscribe"
   private val PARAM_EXAMPLE_SHOULD_USE_SCHEMA_REGISTRY = "example.should.use.schema.registry"
 
+  private val PARAM_KEY_SCHEMA_NAME = "key.schema.name"
+  private val PARAM_KEY_SCHEMA_NAMESPACE = "key.schema.namespace"
+
+  private val PARAM_VALUE_SCHEMA_NAME = "value.schema.name"
+  private val PARAM_VALUE_SCHEMA_NAMESPACE = "value.schema.namespace"
+
   def main(args: Array[String]): Unit = {
 
     // there is an example file at /src/test/resources/AvroReadingExample.properties
@@ -67,10 +73,12 @@ object ConfluentKafkaAvroReaderWithKey {
     val commonRegistryConfig = Map(
       SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> properties(PARAM_OPTION_SUBSCRIBE),
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> properties(SchemaManager.PARAM_SCHEMA_REGISTRY_URL),
-      SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY ->
-        properties(SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY),
-      SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY ->
-        properties(SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+
+      SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_KEY_SCHEMA_NAME),
+      SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_KEY_SCHEMA_NAMESPACE),
+
+      SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_SCHEMA_NAME),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_SCHEMA_NAMESPACE)
     )
 
     val valueRegistryConfig = commonRegistryConfig ++ Map(

--- a/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroWriter.scala
+++ b/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroWriter.scala
@@ -33,8 +33,10 @@ object ConfluentKafkaAvroWriter {
   private val PARAM_JOB_NAME = "job.name"
   private val PARAM_JOB_MASTER = "job.master"
   private val PARAM_PAYLOAD_AVRO_SCHEMA = "payload.avro.schema"
-  private val PARAM_AVRO_RECORD_NAME = "avro.record.name"
-  private val PARAM_AVRO_RECORD_NAMESPACE = "avro.record.namespace"
+  private val PARAM_KEY_AVRO_RECORD_NAME = "avro.key.record.name"
+  private val PARAM_KEY_AVRO_RECORD_NAMESPACE = "avro.key.record.namespace"
+  private val PARAM_VALUE_AVRO_RECORD_NAME = "avro.value.record.name"
+  private val PARAM_VALUE_AVRO_RECORD_NAMESPACE = "avro.value.record.namespace"
   private val PARAM_INFER_SCHEMA = "infer.schema"
   private val PARAM_LOG_LEVEL = "log.level"
   private val PARAM_TEST_DATA_ENTRIES = "test.data.entries"
@@ -77,8 +79,10 @@ object ConfluentKafkaAvroWriter {
       SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> properties(PARAM_TOPIC),
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> properties(SchemaManager.PARAM_SCHEMA_REGISTRY_URL),
       SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY -> properties(SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY),
-      SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAME),
-      SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAMESPACE)
+      SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAMESPACE),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAMESPACE)
     )
 
     val source = scala.io.Source.fromFile(properties(PARAM_PAYLOAD_AVRO_SCHEMA))

--- a/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroWriterWithKey.scala
+++ b/src/main/scala/za/co/absa/abris/examples/ConfluentKafkaAvroWriterWithKey.scala
@@ -38,8 +38,10 @@ object ConfluentKafkaAvroWriterWithKey {
   private val PARAM_JOB_MASTER = "job.master"
   private val PARAM_PAYLOAD_AVRO_SCHEMA = "payload.avro.schema"
   private val PARAM_KEY_AVRO_SCHEMA = "key.avro.schema"
-  private val PARAM_AVRO_RECORD_NAME = "avro.record.name"
-  private val PARAM_AVRO_RECORD_NAMESPACE = "avro.record.namespace"
+  private val PARAM_KEY_AVRO_RECORD_NAME = "avro.key.record.name"
+  private val PARAM_KEY_AVRO_RECORD_NAMESPACE = "avro.key.record.namespace"
+  private val PARAM_VALUE_AVRO_RECORD_NAME = "avro.value.record.name"
+  private val PARAM_VALUE_AVRO_RECORD_NAMESPACE = "avro.value.record.namespace"
   private val PARAM_INFER_SCHEMA = "infer.schema"
   private val PARAM_LOG_LEVEL = "log.level"
   private val PARAM_TEST_DATA_ENTRIES = "test.data.entries"
@@ -81,8 +83,10 @@ object ConfluentKafkaAvroWriterWithKey {
     val commonRegistryConfig = Map(
       SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> properties(PARAM_TOPIC),
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> properties(SchemaManager.PARAM_SCHEMA_REGISTRY_URL),
-      SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAME),
-      SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAMESPACE)
+      SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_KEY_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_KEY_AVRO_RECORD_NAMESPACE),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAMESPACE)
     )
 
     val valueRegistryConfig = commonRegistryConfig +

--- a/src/main/scala/za/co/absa/abris/examples/KafkaAvroWriter.scala
+++ b/src/main/scala/za/co/absa/abris/examples/KafkaAvroWriter.scala
@@ -33,8 +33,10 @@ object KafkaAvroWriter {
   private val PARAM_JOB_NAME = "job.name"
   private val PARAM_JOB_MASTER = "job.master"
   private val PARAM_PAYLOAD_AVRO_SCHEMA = "payload.avro.schema"
-  private val PARAM_AVRO_RECORD_NAME = "avro.record.name"
-  private val PARAM_AVRO_RECORD_NAMESPACE = "avro.record.namespace"
+  private val PARAM_KEY_AVRO_RECORD_NAME = "avro.key.record.name"
+  private val PARAM_KEY_AVRO_RECORD_NAMESPACE = "avro.key.record.namespace"
+  private val PARAM_VALUE_AVRO_RECORD_NAME = "avro.value.record.name"
+  private val PARAM_VALUE_AVRO_RECORD_NAMESPACE = "avro.value.record.namespace"
   private val PARAM_INFER_SCHEMA = "infer.schema"
   private val PARAM_LOG_LEVEL = "log.level"
   private val PARAM_TEST_DATA_ENTRIES = "test.data.entries"
@@ -75,8 +77,10 @@ object KafkaAvroWriter {
       SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> properties(PARAM_TOPIC),
       SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> properties(SchemaManager.PARAM_SCHEMA_REGISTRY_URL),
       SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY -> properties(SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY),
-      SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAME),
-      SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_AVRO_RECORD_NAMESPACE)
+      SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAMESPACE),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAME),
+      SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> properties(PARAM_VALUE_AVRO_RECORD_NAMESPACE)
     )
 
     val source = scala.io.Source.fromFile(properties(PARAM_PAYLOAD_AVRO_SCHEMA))

--- a/src/main/scala/za/co/absa/abris/examples/utils/ExamplesUtils.scala
+++ b/src/main/scala/za/co/absa/abris/examples/utils/ExamplesUtils.scala
@@ -139,8 +139,8 @@ object ExamplesUtils {
         SchemaManager.PARAM_VALUE_SCHEMA_ID,
         SchemaManager.PARAM_KEY_SCHEMA_NAMING_STRATEGY,
         SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY,
-        SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY,
-        SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
+        SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY,
+        SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY)
 
       val confs = scala.collection.mutable.Map[String,String](
         SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> props.getProperty(subscribeParamKey))

--- a/src/test/resources/AvroReadingExample.properties
+++ b/src/test/resources/AvroReadingExample.properties
@@ -29,8 +29,11 @@ key.schema.id=latest
 
 example.should.use.schema.registry=true
 
-# key.schema.naming.strategy=record.name
-value.schema.naming.strategy=topic.name
+key.schema.naming.strategy=topic.name
+value.schema.naming.strategy=topic.record.name
 
-schema.name=native_complete
-schema.namespace=all-types.test
+key.schema.name=key_record
+key.schema.namespace=all-types.test
+
+value.schema.name=native_complete
+value.schema.namespace=all-types.test

--- a/src/test/resources/DataframeWritingExample.properties
+++ b/src/test/resources/DataframeWritingExample.properties
@@ -5,9 +5,10 @@ job.master=local[2]
 key.avro.schema=src/test/resources/example_key_schema.avsc
 payload.avro.schema=src/test/resources/example_payload_schema.avsc
 
-avro.record.name=RecordName
-
-avro.record.namespace=RecordNamespace
+avro.key.record.name=RecordName
+avro.key.record.namespace=RecordNamespace
+avro.value.record.name=RecordName
+avro.value.record.namespace=RecordNamespace
 
 log.level=INFO
 
@@ -38,9 +39,9 @@ option.kafka.bootstrap.servers=PLAINTEXT://localhost:9092
 
 option.topic=test_topic
 
-key.schema.naming.strategy=record.name
+key.schema.naming.strategy=topic.name
 
-value.schema.naming.strategy=topic.name
+value.schema.naming.strategy=topic.record.name
 
 # security options (comment in case the Kafka cluster is not secured)
 #option.kafka.security.protocol=SSL

--- a/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
@@ -43,8 +43,8 @@ class CatalystAvroConversionSpec extends FlatSpec with Matchers with BeforeAndAf
     SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> "test_topic",
     SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "dummy",
     SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY -> "topic.record.name",
-    SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "native_complete",
-    SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
+    SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "native_complete",
+    SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
   )
 
   private val latestIdSchemaRegistryConfig = schemaRegistryConfig ++ Map(
@@ -365,8 +365,8 @@ class CatalystAvroConversionSpec extends FlatSpec with Matchers with BeforeAndAf
     SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> "test_topic",
     SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "dummy",
     SchemaManager.PARAM_KEY_SCHEMA_NAMING_STRATEGY -> "topic.name",
-    SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "native_complete",
-    SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
+    SchemaManager.PARAM_KEY_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "native_complete",
+    SchemaManager.PARAM_KEY_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
   )
 
   private val latestSchemaRegistryConfigForKey = schemaRegistryConfigForKey ++ Map(

--- a/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
@@ -39,8 +39,8 @@ class SchemaEvolutionSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     SchemaManager.PARAM_SCHEMA_REGISTRY_TOPIC -> "test_topic",
     SchemaManager.PARAM_SCHEMA_REGISTRY_URL -> "dummy",
     SchemaManager.PARAM_VALUE_SCHEMA_NAMING_STRATEGY -> "topic.record.name",
-    SchemaManager.PARAM_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "record_name",
-    SchemaManager.PARAM_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
+    SchemaManager.PARAM_VALUE_SCHEMA_NAME_FOR_RECORD_STRATEGY -> "record_name",
+    SchemaManager.PARAM_VALUE_SCHEMA_NAMESPACE_FOR_RECORD_STRATEGY -> "all-types.test"
   )
 
   private val latestSchemaRegistryConfig = schemaRegistryConfig ++ Map(


### PR DESCRIPTION
Previously only either key or value could use record name or topic record name strategies since there was only one pair of settings for the schema name and namespaces. 

This PR solves that issue.