### PR TITLE
Bump to confluent 5.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<!--Platforms-->
 		<spark.version>2.4.4</spark.version>
 		<kafka.spark.version>0-10</kafka.spark.version>
-		<confluent.version>5.3.1</confluent.version>
+		<confluent.version>5.5.1</confluent.version>
 
 		<!--Libs-->
         <spark.avro.version>2.4.4</spark.avro.version>

--- a/src/main/scala/za/co/absa/abris/avro/subject/SubjectNameStrategyAdapter.scala
+++ b/src/main/scala/za/co/absa/abris/avro/subject/SubjectNameStrategyAdapter.scala
@@ -19,12 +19,13 @@ package za.co.absa.abris.avro.subject
 import io.confluent.kafka.serializers.subject.TopicNameStrategy
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy
 import org.apache.avro.Schema
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 
-private[avro] class SubjectNameStrategyAdapter(strategy: SubjectNameStrategy[Schema]) {
+private[avro] class SubjectNameStrategyAdapter(strategy: SubjectNameStrategy) {
 
-  def subjectName(topic: String, isKey: Boolean, schema: Schema): String = strategy.subjectName(topic, isKey, schema)
+  def subjectName(topic: String, isKey: Boolean, schema: Schema): String = strategy.subjectName(topic, isKey, new AvroSchema(schema))
 
-  def isAdapteeType(c: Class[_ <: SubjectNameStrategy[Schema]]) : Boolean = strategy.getClass == c
+  def isAdapteeType(c: Class[_ <: SubjectNameStrategy]) : Boolean = strategy.getClass == c
 
   /**
     * Checks if the Schema definition is compatible with the adaptee strategy


### PR DESCRIPTION
Also had to patch `src/main/scala/za/co/absa/abris/avro/subject/SubjectNameStrategyAdapter.scala` to match changes with confluent schema registry.