### PR TITLE
Add not found message for Apicurio Registry in SchemaManager.exists

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManager.scala
@@ -122,7 +122,8 @@ class SchemaManager(
   private def exists(subject: String): Boolean = {
     Try(schemaRegistryClient.getLatestSchemaMetadata(subject)) match {
       case Success(_) => true
-      case Failure(e) if e.getMessage.contains("Subject not found") || e.getMessage.contains("No schema registered") =>
+      case Failure(e) if e.getMessage.contains("Subject not found") || e.getMessage.contains("No schema registered")
+        || e.getMessage.contains("No artifact with ID") =>
         logInfo(s"Subject not registered: '$subject'")
         false
       case Failure(e) =>


### PR DESCRIPTION
Hi ABRiS team!
I'd like to propose to add this line to support the [Apicurio Registry](https://www.apicur.io/registry/) which has the same REST interface as the confluent registry but sometimes returns different error strings. 
This change will avoid logging an error when the schema does not exist (e.g. when writing into a new Kafka topic)

Alternatively instead of the error message if the error is of type `RestClientException` one could check the status/error code for 404. But this introduces the least amount of changes. Please tell if you're ok with the change or I should adapt it in a different way.