### PR TITLE
Downgrade confluent 3.2 branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,11 +71,11 @@
 		<!--Platforms-->
 		<spark.version>2.4.4</spark.version>
 		<kafka.spark.version>0-10</kafka.spark.version>
-		<confluent.version>5.3.1</confluent.version>
+		<confluent.version>5.3.4</confluent.version>
 
 		<!--Libs-->
         <spark.avro.version>2.4.4</spark.avro.version>
-		<avro.version>1.9.2</avro.version>
+		<avro.version>1.8.2</avro.version>
 	</properties>
 
     <scm>
@@ -128,23 +128,9 @@
             <scope>test</scope>
         </dependency>
 
-		<!-- Avro -->
-		<dependency>
-			<groupId>org.apache.avro</groupId>
-			<artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-            <exclusions>
-                <exclusion>
-                    <!-- use the jackson libraries specified by Spark sql -->
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-		<!-- Spark -->
-		<dependency>
-			<groupId>org.apache.spark</groupId>
+        <!-- Spark -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
@@ -165,6 +151,20 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-avro_${scala.compat.version}</artifactId>
             <version>${spark.avro.version}</version>
+        </dependency>
+
+		<!-- Avro -->
+		<dependency>
+			<groupId>org.apache.avro</groupId>
+			<artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- use the jackson libraries specified by Spark sql -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Spark Kafka -->

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<!--Platforms-->
 		<spark.version>2.4.4</spark.version>
 		<kafka.spark.version>0-10</kafka.spark.version>
-		<confluent.version>5.5.1</confluent.version>
+		<confluent.version>5.3.1</confluent.version>
 
 		<!--Libs-->
         <spark.avro.version>2.4.4</spark.avro.version>

--- a/src/main/scala/za/co/absa/abris/avro/subject/SubjectNameStrategyAdapter.scala
+++ b/src/main/scala/za/co/absa/abris/avro/subject/SubjectNameStrategyAdapter.scala
@@ -19,13 +19,12 @@ package za.co.absa.abris.avro.subject
 import io.confluent.kafka.serializers.subject.TopicNameStrategy
 import io.confluent.kafka.serializers.subject.strategy.SubjectNameStrategy
 import org.apache.avro.Schema
-import io.confluent.kafka.schemaregistry.avro.AvroSchema
 
-private[avro] class SubjectNameStrategyAdapter(strategy: SubjectNameStrategy) {
+private[avro] class SubjectNameStrategyAdapter(strategy: SubjectNameStrategy[Schema]) {
 
-  def subjectName(topic: String, isKey: Boolean, schema: Schema): String = strategy.subjectName(topic, isKey, new AvroSchema(schema))
+  def subjectName(topic: String, isKey: Boolean, schema: Schema): String = strategy.subjectName(topic, isKey, schema)
 
-  def isAdapteeType(c: Class[_ <: SubjectNameStrategy]) : Boolean = strategy.getClass == c
+  def isAdapteeType(c: Class[_ <: SubjectNameStrategy[Schema]]) : Boolean = strategy.getClass == c
 
   /**
     * Checks if the Schema definition is compatible with the adaptee strategy


### PR DESCRIPTION
Abris #165 Revert "Bump to confluent 5.5.1 (#150)" 

Abris #165 polishing dependencies

- use Spark dependency first to give it priority for transitive dependencies
- use the same avro as Spark
- use the latest patch for confluent schema registry