### PR TITLE
Abris #165 downgrade confluent to be spark compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,11 @@
         <!--Platforms-->
         <spark.version>2.4.4</spark.version>
         <kafka.spark.version>0-10</kafka.spark.version>
-        <confluent.version>5.5.1</confluent.version>
+        <confluent.version>5.3.4</confluent.version>
 
         <!--Libs-->
         <spark.avro.version>2.4.6</spark.avro.version>
-        <avro.version>1.9.2</avro.version>
+        <avro.version>1.8.2</avro.version>
     </properties>
 
     <scm>
@@ -129,20 +129,6 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Avro -->
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-            <exclusions>
-                <exclusion>
-                    <!-- use the jackson libraries specified by Spark sql -->
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
         <!-- Spark -->
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -166,6 +152,20 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-avro_${scala.compat.version}</artifactId>
             <version>${spark.avro.version}</version>
+        </dependency>
+
+        <!-- Avro -->
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+            <exclusions>
+                <exclusion>
+                    <!-- use the jackson libraries specified by Spark sql -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Spark Kafka -->

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 import scala.collection.concurrent
 
 /**
- * This thread-safe factory creates [[SchemaManager]] and also manages the instances of [[SchemaRegistryClient]]
+ * This thread-safe factory creates [[SchemaManager]] and also manages the instances of SchemaRegistryClient
  * used by allowing caching of the references in order to avoid creating instances in every call that can be
  * used to cache schemas.
  * This factory also allows us to mock the client for testing purposes.

--- a/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.abris.avro.registry
 
-import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.serializers.subject.{RecordNameStrategy, TopicNameStrategy, TopicRecordNameStrategy}
 import org.apache.avro.Schema
 
@@ -53,7 +52,7 @@ object SchemaSubject{
   def usingRecordNameStrategy(
     schema: Schema
   ): SchemaSubject = {
-    new SchemaSubject(RECORD_NAME_STRATEGY.subjectName("", false,  new AvroSchema(schema)))
+    new SchemaSubject(RECORD_NAME_STRATEGY.subjectName("", false, schema))
   }
 
   def usingTopicRecordNameStrategy(
@@ -69,9 +68,9 @@ object SchemaSubject{
     topicName: String,
     schema: Schema
   ): SchemaSubject = {
-    new SchemaSubject(TOPIC_RECORD_NAME_STRATEGY.subjectName(topicName, false, new AvroSchema(schema)))
+    new SchemaSubject(TOPIC_RECORD_NAME_STRATEGY.subjectName(topicName, false, schema))
   }
 
   private def createDummySchema(name: String, namespace: String) =
-    new AvroSchema(Schema.createRecord(name, "", namespace, false))
+    Schema.createRecord(name, "", namespace, false)
 }


### PR DESCRIPTION
- use Spark dependency first to give it priority for transitive dependencies
- use the same avro as Spark
- use the latest patch for confluent schema registry