### PR TITLE
Fix subject string in debug messages

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
@@ -25,7 +25,9 @@ import org.apache.avro.Schema
  * https://docs.confluent.io/current/schema-registry/serdes-develop/index.html#how-the-naming-strategies-work
  *
  */
-class SchemaSubject(val asString: String)
+class SchemaSubject(val asString: String) {
+  override def toString: String = asString
+}
 
 object SchemaSubject{
   private val TOPIC_NAME_STRATEGY = new TopicNameStrategy()


### PR DESCRIPTION
Currently, debug messages are printed like this:
`Caused by: java.security.InvalidParameterException: Schema could not be registered for subject 'za.co.absa.abris.avro.registry.SchemaSubject@64d35d72'`, which is a regression from version 3.2.
This PR fixes that.
