### PR TITLE
Add mock registry support via URL

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
@@ -19,12 +19,12 @@ package za.co.absa.abris.avro.read.confluent
 
 import java.util
 import java.util.List
-
 import io.confluent.common.config.ConfigException
 import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
 import io.confluent.kafka.schemaregistry.testutil.MockSchemaRegistry
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import org.apache.spark.internal.Logging
+import za.co.absa.abris.avro.registry.AbrisMockSchemaRegistryClient
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
@@ -60,7 +60,7 @@ object SchemaManagerFactory extends Logging {
           logInfo(msg = s"Configuring new Schema Registry instance of type " +
             s"'${classOf[MockSchemaRegistry].getCanonicalName}'")
 
-          MockSchemaRegistry.getClientForScope(scope)
+          new AbrisMockSchemaRegistryClient()
         case None =>
           logInfo(msg = s"Configuring new Schema Registry instance of type " +
             s"'${classOf[CachedSchemaRegistryClient].getCanonicalName}'")

--- a/src/main/scala/za/co/absa/abris/avro/registry/AbrisMockSchemaRegistryClient.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/AbrisMockSchemaRegistryClient.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package za.co.absa.abris.avro
-
-import java.io.IOException
+package za.co.absa.abris.avro.registry
 
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
 import io.confluent.kafka.schemaregistry.client.{MockSchemaRegistryClient, SchemaMetadata}
 
+import java.io.IOException
 
-private class AbrisMockSchemaRegistryClient extends MockSchemaRegistryClient {
+
+class AbrisMockSchemaRegistryClient extends MockSchemaRegistryClient {
 
   /**
    * MockSchemaRegistryClient is throwing different Exception than the mocked client, this is a workaround
@@ -33,7 +33,7 @@ private class AbrisMockSchemaRegistryClient extends MockSchemaRegistryClient {
     try (super.getLatestSchemaMetadata(subject))
     catch {
       case e: IOException if e.getMessage == "No schema registered under subject!"
-        => throw new RestClientException("No schema registered under subject!", 404,40401)
+        => throw new RestClientException("No schema registered under subject!", 404, 40401)
     }
   }
 }

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerSpec.scala
@@ -17,9 +17,8 @@
 package za.co.absa.abris.avro.read.confluent
 
 import org.scalatest.{BeforeAndAfter, FlatSpec}
-import za.co.absa.abris.avro.AbrisMockSchemaRegistryClient
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
-import za.co.absa.abris.avro.registry.{LatestVersion, NumVersion, SchemaSubject}
+import za.co.absa.abris.avro.registry.{AbrisMockSchemaRegistryClient, LatestVersion, NumVersion, SchemaSubject}
 import za.co.absa.abris.config.AbrisConfig
 
 class schemaManagerSpec extends FlatSpec with BeforeAndAfter {

--- a/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
@@ -20,12 +20,11 @@ import org.apache.spark.sql.catalyst.encoders.RowEncoder
 import org.apache.spark.sql.functions.struct
 import org.apache.spark.sql.{DataFrame, Encoder, Row, SparkSession}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
-import za.co.absa.abris.avro.AbrisMockSchemaRegistryClient
 import za.co.absa.abris.avro.format.SparkAvroConversions
 import za.co.absa.abris.avro.functions._
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
-import za.co.absa.abris.avro.registry.SchemaSubject
+import za.co.absa.abris.avro.registry.{AbrisMockSchemaRegistryClient, SchemaSubject}
 import za.co.absa.abris.config.AbrisConfig
 import za.co.absa.abris.examples.data.generation.{ComplexRecordsGenerator, TestSchemas}
 

--- a/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
@@ -19,11 +19,10 @@ package za.co.absa.abris.avro.sql
 import org.apache.spark.sql.functions.{lit, struct}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
-import za.co.absa.abris.avro.AbrisMockSchemaRegistryClient
 import za.co.absa.abris.avro.format.SparkAvroConversions
 import za.co.absa.abris.avro.functions._
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
-import za.co.absa.abris.avro.registry.SchemaSubject
+import za.co.absa.abris.avro.registry.{AbrisMockSchemaRegistryClient, SchemaSubject}
 import za.co.absa.abris.config.AbrisConfig
 
 class SchemaEvolutionSpec extends FlatSpec with Matchers with BeforeAndAfterEach


### PR DESCRIPTION
Confluent has an internal `MockSchemaRegistryClient` that is used when the registry url starts with `mock://`. I'm proposing here to do the same in the `SchemaManagerFactory`. This will improve compatibility with the standard confluent libraries as well as make it easy for clients to configure ABRiS to use a mock library.