### PR TITLE
Support writer schema for reading simple avro

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/functions.scala
+++ b/src/main/scala/za/co/absa/abris/avro/functions.scala
@@ -63,9 +63,7 @@ object functions {
   def from_avro(column: Column, config: FromAvroConfig): Column = {
     new Column(AvroDataToCatalyst(
       column.expr,
-      config.schemaString,
-      config.schemaRegistryConf,
-      config.schemaRegistryConf.isDefined
+      config
     ))
   }
 

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -56,11 +56,13 @@ case class AvroDataToCatalyst(
   // Avro schema that was used for data serialization
   @transient private lazy val writerSchema = config.writerSchema.map(s => AvroSchemaUtils.parse(s))
 
+  // Reused GenericDatumReaders per writer schema
   @transient private lazy val vanillaReader: GenericDatumReader[Any] = new GenericDatumReader[Any](writerSchema.getOrElse(avroSchema), avroSchema)
   @transient private lazy val confluentReaderCache: ConcurrentHashMap[Int, GenericDatumReader[Any]] = new ConcurrentHashMap[Int, GenericDatumReader[Any]]()
 
   @transient private var decoder: BinaryDecoder = _
 
+  // Reused result object (usually of type IndexedRecord)
   @transient private var result: Any = _
 
   override def nullSafeEval(input: Any): Any = {

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -61,7 +61,7 @@ case class AvroDataToCatalyst(
 
   @transient private var decoder: BinaryDecoder = _
 
-  @transient val deserializer = new AvroDeserializer(avroSchema, dataType)
+  @transient private lazy val deserializer = new AvroDeserializer(avroSchema, dataType)
 
   // Reused result object (usually of type IndexedRecord)
   @transient private var result: Any = _

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -130,9 +130,7 @@ case class AvroDataToCatalyst(
 
     val reader = confluentReaderCache.getOrElseUpdate(schemaId, {
       val writerSchema = getWriterSchema(schemaId)
-      val reader = new GenericDatumReader[Any](writerSchema, avroSchema)
-      confluentReaderCache.put(schemaId, reader)
-      reader
+      new GenericDatumReader[Any](writerSchema, avroSchema)
     })
 
     result = reader.read(result, decoder)

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -45,7 +45,7 @@ case class AvroDataToCatalyst(
 
   override def nullable: Boolean = true
 
-  private val confluentCompliant = config.confluent
+  private val confluentCompliant = config.schemaRegistryConf.isDefined
 
   @transient private lazy val schemaManager = SchemaManagerFactory.create(config.schemaRegistryConf.get)
 

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -153,8 +153,8 @@ class FromSimpleAvroConfigFragment{
   def downloadSchemaByVersion(schemaVersion: Int): FromStrategyConfigFragment =
     new FromStrategyConfigFragment(NumVersion(schemaVersion), false)
 
-  def provideSchema(schema: String): FromAvroConfig =
-    new FromAvroConfig(schema, None)
+  def provideSchema(schema: String, writerSchema: String = ""): FromAvroConfig =
+    new FromAvroConfig(schema, if (writerSchema.isEmpty) Some(schema) else Some(writerSchema), None, false)
 }
 
 class FromStrategyConfigFragment(version: SchemaVersion, confluent: Boolean) {
@@ -192,11 +192,11 @@ class FromSchemaDownloadingConfigFragment(
     case Left(coordinate) => {
       val schemaManager = SchemaManagerFactory.create(config)
       val schema = schemaManager.getSchema(coordinate)
-      new FromAvroConfig(schema.toString, if (confluent) Some(config) else None)
+      new FromAvroConfig(schema.toString, None, if (confluent) Some(config) else None, confluent)
     }
     case Right(schemaString) =>
       if (confluent) {
-        new FromAvroConfig(schemaString, Some(config))
+        new FromAvroConfig(schemaString, None, Some(config), confluent)
       } else {
         throw new UnsupportedOperationException("Unsupported config permutation")
       }
@@ -218,4 +218,4 @@ class FromConfluentAvroConfigFragment {
 }
 
 
-class FromAvroConfig(val schemaString: String, val schemaRegistryConf: Option[Map[String,String]])
+case class FromAvroConfig(schemaString: String, writerSchema: Option[String], schemaRegistryConf: Option[Map[String,String]], confluent: Boolean = false)

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -154,7 +154,7 @@ class FromSimpleAvroConfigFragment{
     new FromStrategyConfigFragment(NumVersion(schemaVersion), false)
 
   def provideSchema(schema: String, writerSchema: String = ""): FromAvroConfig =
-    new FromAvroConfig(schema, if (writerSchema.isEmpty) Some(schema) else Some(writerSchema), None, false)
+    new FromAvroConfig(schema, if (writerSchema.isEmpty) Some(schema) else Some(writerSchema), None)
 }
 
 class FromStrategyConfigFragment(version: SchemaVersion, confluent: Boolean) {
@@ -192,11 +192,11 @@ class FromSchemaDownloadingConfigFragment(
     case Left(coordinate) => {
       val schemaManager = SchemaManagerFactory.create(config)
       val schema = schemaManager.getSchema(coordinate)
-      new FromAvroConfig(schema.toString, None, if (confluent) Some(config) else None, confluent)
+      new FromAvroConfig(schema.toString, None, if (confluent) Some(config) else None)
     }
     case Right(schemaString) =>
       if (confluent) {
-        new FromAvroConfig(schemaString, None, Some(config), confluent)
+        new FromAvroConfig(schemaString, None, Some(config))
       } else {
         throw new UnsupportedOperationException("Unsupported config permutation")
       }
@@ -218,4 +218,4 @@ class FromConfluentAvroConfigFragment {
 }
 
 
-case class FromAvroConfig(schemaString: String, writerSchema: Option[String], schemaRegistryConf: Option[Map[String,String]], confluent: Boolean = false)
+case class FromAvroConfig(schemaString: String, writerSchema: Option[String], schemaRegistryConf: Option[Map[String,String]])


### PR DESCRIPTION
This PR introduces a configuration for a writer schema for the simple avro format. That way a reader format can differ from the format that was used for serializing the record. This allows e.g. for default fields or fewer fields in the reader schema. Also fields can be forced to be nullable if the reader schema defines this. I'm not sure if this is partially meant with #155.

Furthermore I'm introducing caches for the GenericDatumReaders and fix the reuse of the result in the reader.read method.