### PR TITLE
Remove log4j.properties from packaged jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
         <spark-30.version>3.0.0</spark-30.version>
 
         <spark.version>${spark-24.version}</spark.version>
+        <spark.scope>provided</spark.scope>
 
         <!-- Cross build properties -->
 
@@ -141,19 +142,19 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+            <scope>${spark.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+            <scope>${spark.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+            <scope>${spark.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -180,13 +181,13 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql-kafka-${kafka.spark.version}_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+            <scope>${spark.scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming-kafka-${kafka.spark.version}_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>provided</scope>
+            <scope>${spark.scope}</scope>
         </dependency>
 
         <!-- Confluent's Kafka and Schema Registry -->
@@ -291,6 +292,15 @@
                     <scalaVersionProperty>scala.version</scalaVersionProperty>
                     <defaultScalaBinaryVersion>${default.scala.compat.version}</defaultScalaBinaryVersion>
                     <defaultScalaVersion>${default.scala.version}</defaultScalaVersion>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>log4j.properties</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <spark-30.version>3.0.0</spark-30.version>
 
         <spark.version>${spark-24.version}</spark.version>
-        <spark.scope>provided</spark.scope>
 
         <!-- Cross build properties -->
 
@@ -142,19 +141,19 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark.scope}</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark.scope}</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark.scope}</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
@@ -181,13 +180,13 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql-kafka-${kafka.spark.version}_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark.scope}</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming-kafka-${kafka.spark.version}_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
-            <scope>${spark.scope}</scope>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Confluent's Kafka and Schema Registry -->


### PR DESCRIPTION
Currently the released jar file includes a `log4j.properties` file. This may disturb logging configuration of projects that are using it. I see that there is example code in the library as well that is using this and it's easier to have a logger configuration file in order to run these examples. 

What do you think about excluding the properties file in the last step when building the jar? So that for tests etc it would be there but it would not be in the final jar that is uploaded to maven.