### PR TITLE
Proposal to support a custom registry client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
@@ -59,8 +59,8 @@ object SchemaManagerFactory extends Logging {
           s"'${classOf[AbrisMockSchemaRegistryClient].getCanonicalName}'")
 
         new AbrisMockSchemaRegistryClient()
-      } else if (configs.contains(AbrisConfig.SCHEMA_REGISTRY_CLASS)) {
-        val cl = Class.forName(configs(AbrisConfig.SCHEMA_REGISTRY_CLASS))
+      } else if (configs.contains(AbrisConfig.REGISTRY_CLIENT_CLASS)) {
+        val cl = Class.forName(configs(AbrisConfig.REGISTRY_CLIENT_CLASS))
         logInfo(msg = s"Configuring new Schema Registry instance of type " +
           s"'${cl.getCanonicalName}'")
         val instance = cl.getDeclaredConstructor(Array(classOf[util.Map[String, String]]): _*)

--- a/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
+++ b/src/main/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactory.scala
@@ -23,6 +23,7 @@ import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, Sch
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import org.apache.spark.internal.Logging
 import za.co.absa.abris.avro.registry.AbrisMockSchemaRegistryClient
+import za.co.absa.abris.config.AbrisConfig
 
 import scala.collection.JavaConverters._
 import scala.collection.concurrent
@@ -58,6 +59,14 @@ object SchemaManagerFactory extends Logging {
           s"'${classOf[AbrisMockSchemaRegistryClient].getCanonicalName}'")
 
         new AbrisMockSchemaRegistryClient()
+      } else if (configs.contains(AbrisConfig.SCHEMA_REGISTRY_CLASS)) {
+        val cl = Class.forName(configs(AbrisConfig.SCHEMA_REGISTRY_CLASS))
+        logInfo(msg = s"Configuring new Schema Registry instance of type " +
+          s"'${cl.getCanonicalName}'")
+        val instance = cl.getDeclaredConstructor(Array(classOf[util.Map[String, String]]): _*)
+            .newInstance(configs.asJava)
+
+        instance.asInstanceOf[SchemaRegistryClient]
       } else {
         logInfo(msg = s"Configuring new Schema Registry instance of type " +
           s"'${classOf[CachedSchemaRegistryClient].getCanonicalName}'")

--- a/src/main/scala/za/co/absa/abris/avro/registry/CustomRegistryClient.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/CustomRegistryClient.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.registry
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+
+/**
+ * This custom registry client can be used as a super class for custom registry clients that differ from the standard
+ * Confluent [[io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient]].
+ * These must implement a constructor that takes a map as input that is the one configured in the AbrisConfig.
+ * The class is constructed in the Spark driver and the Spark executor.
+ */
+abstract class CustomRegistryClient(config: java.util.Map[String, String]) extends SchemaRegistryClient {
+
+}

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -27,7 +27,7 @@ object AbrisConfig {
   def fromConfluentAvro: FromConfluentAvroConfigFragment = new FromConfluentAvroConfigFragment()
 
   val SCHEMA_REGISTRY_URL = "schema.registry.url"
-  val SCHEMA_REGISTRY_CLASS = "schema.registry.class"
+  val REGISTRY_CLIENT_CLASS = "abris.registryClient.class"
 }
 
 /*

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -27,6 +27,7 @@ object AbrisConfig {
   def fromConfluentAvro: FromConfluentAvroConfigFragment = new FromConfluentAvroConfigFragment()
 
   val SCHEMA_REGISTRY_URL = "schema.registry.url"
+  val SCHEMA_REGISTRY_CLASS = "schema.registry.class"
 }
 
 /*

--- a/src/test/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtilsSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/parsing/utils/AvroSchemaUtilsSpec.scala
@@ -29,6 +29,8 @@ class AvroSchemaUtilsSpec extends AnyFlatSpec with Matchers {
     .builder()
     .appName("unitTest")
     .master("local[2]")
+    .config("spark.driver.bindAddress", "localhost")
+    .config("spark.ui.enabled", "false")
     .getOrCreate()
 
   import spark.implicits._

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
@@ -16,8 +16,9 @@
 
 package za.co.absa.abris.avro.read.confluent
 
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
 import org.scalatest.{BeforeAndAfterEach, FlatSpec}
+import za.co.absa.abris.avro.registry.MyRegistry
 import za.co.absa.abris.config.AbrisConfig
 
 import scala.reflect.runtime.{universe => ru}
@@ -27,6 +28,11 @@ class SchemaManagerFactorySpec extends FlatSpec with BeforeAndAfterEach {
   private val schemaRegistryConfig1 = Map(AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy")
 
   private val schemaRegistryConfig2 = Map(AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy_sr_2")
+
+  private val schemaRegistryConfig3 = Map(
+    AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy_sr_2",
+    AbrisConfig.SCHEMA_REGISTRY_CLASS -> "za.co.absa.abris.avro.registry.MyRegistry",
+  )
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -60,4 +66,17 @@ class SchemaManagerFactorySpec extends FlatSpec with BeforeAndAfterEach {
     assert(!res1.eq(res2))
   }
 
+  it should "create a schema manager with a custom schema registry client depending on the configs passed" in {
+    val schemaManagerRef1 = SchemaManagerFactory.create(schemaRegistryConfig1)
+    val schemaManagerRef3 = SchemaManagerFactory.create(schemaRegistryConfig3)
+
+    val m = ru.runtimeMirror(schemaManagerRef1.getClass.getClassLoader)
+    val fieldTerm = ru.typeOf[SchemaManager].decl(ru.TermName("schemaRegistryClient")).asTerm
+
+    val res1 = m.reflect(schemaManagerRef1).reflectField(fieldTerm).get.asInstanceOf[SchemaRegistryClient]
+    val res3 = m.reflect(schemaManagerRef3).reflectField(fieldTerm).get.asInstanceOf[SchemaRegistryClient]
+    assert(!res1.eq(res3))
+    assert(res1.isInstanceOf[CachedSchemaRegistryClient])
+    assert(res3.isInstanceOf[MyRegistry])
+  }
 }

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
@@ -31,7 +31,7 @@ class SchemaManagerFactorySpec extends FlatSpec with BeforeAndAfterEach {
 
   private val schemaRegistryConfig3 = Map(
     AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy_sr_2",
-    AbrisConfig.SCHEMA_REGISTRY_CLASS -> "za.co.absa.abris.avro.registry.MyRegistry"
+    AbrisConfig.REGISTRY_CLIENT_CLASS -> "za.co.absa.abris.avro.registry.MyRegistry"
   )
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
@@ -31,7 +31,7 @@ class SchemaManagerFactorySpec extends FlatSpec with BeforeAndAfterEach {
 
   private val schemaRegistryConfig3 = Map(
     AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy_sr_2",
-    AbrisConfig.SCHEMA_REGISTRY_CLASS -> "za.co.absa.abris.avro.registry.MyRegistry",
+    AbrisConfig.SCHEMA_REGISTRY_CLASS -> "za.co.absa.abris.avro.registry.MyRegistry"
   )
 
   override def beforeEach(): Unit = {

--- a/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
@@ -16,7 +16,7 @@
 
 package za.co.absa.abris.avro.registry
 
-import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryClient}
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata
 import org.apache.avro.Schema
 
 import java.util
@@ -24,7 +24,7 @@ import java.util
 /**
  * This is a dummy registry that does nothing.
  */
-class MyRegistry(configs: util.Map[String, String]) extends SchemaRegistryClient {
+class MyRegistry(configs: util.Map[String, String]) extends CustomRegistryClient(configs) {
 
   override def register(s: String, schema: Schema): Int = ???
 

--- a/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.registry
+
+import io.confluent.kafka.schemaregistry.client.{SchemaMetadata, SchemaRegistryClient}
+import org.apache.avro.Schema
+
+import java.util
+
+/**
+ * This is a dummy registry that does nothing.
+ */
+class MyRegistry(configs: util.Map[String, String]) extends SchemaRegistryClient {
+
+  override def register(s: String, schema: Schema): Int = ???
+
+  override def register(s: String, schema: Schema, i: Int, i1: Int): Int = ???
+
+  override def getByID(i: Int): Schema = ???
+
+  override def getById(i: Int): Schema = ???
+
+  override def getBySubjectAndID(s: String, i: Int): Schema = ???
+
+  override def getBySubjectAndId(s: String, i: Int): Schema = ???
+
+  override def getLatestSchemaMetadata(s: String): SchemaMetadata = ???
+
+  override def getSchemaMetadata(s: String, i: Int): SchemaMetadata = ???
+
+  override def getVersion(s: String, schema: Schema): Int = ???
+
+  override def getAllVersions(s: String): util.List[Integer] = ???
+
+  override def testCompatibility(s: String, schema: Schema): Boolean = ???
+
+  override def updateCompatibility(s: String, s1: String): String = ???
+
+  override def getCompatibility(s: String): String = ???
+
+  override def setMode(s: String): String = ???
+
+  override def setMode(s: String, s1: String): String = ???
+
+  override def getMode: String = ???
+
+  override def getMode(s: String): String = ???
+
+  override def getAllSubjects: util.Collection[String] = ???
+
+  override def getId(s: String, schema: Schema): Int = ???
+
+  override def deleteSubject(s: String): util.List[Integer] = ???
+
+  override def deleteSubject(map: util.Map[String, String], s: String): util.List[Integer] = ???
+
+  override def deleteSchemaVersion(s: String, s1: String): Integer = ???
+
+  override def deleteSchemaVersion(map: util.Map[String, String], s: String, s1: String): Integer = ???
+
+  override def reset(): Unit = ???
+}

--- a/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
@@ -34,6 +34,8 @@ class CatalystAvroConversionSpec extends FlatSpec with Matchers with BeforeAndAf
     .builder()
     .appName("unitTest")
     .master("local[2]")
+    .config("spark.driver.bindAddress", "localhost")
+    .config("spark.ui.enabled", "false")
     .getOrCreate()
 
   import spark.implicits._

--- a/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/SchemaEvolutionSpec.scala
@@ -31,6 +31,8 @@ class SchemaEvolutionSpec extends FlatSpec with Matchers with BeforeAndAfterEach
     .builder()
     .appName("unitTest")
     .master("local[2]")
+    .config("spark.driver.bindAddress", "localhost")
+    .config("spark.ui.enabled", "false")
     .getOrCreate()
 
   import spark.implicits._


### PR DESCRIPTION
This PR proposes to support a custom registry client that can be specified in the config map that is configured with `usingSchemaRegistry(config: Map[String, String])` .

This enables custom registry clients that implement different protocols or authentications. 
Configuration of these clients can be done by the same `Map[String, String]`.

An example custom registry (with no actual implementations of the functions) can be found in `MyRegistry`.