### PR TITLE
Add full end to end

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,6 +225,65 @@
         </resources>
 
         <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.6.1</version>
+                <executions>
+                    <execution>
+                        <id>install-schemaReg</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>artifact</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <artifactId>spring-schema-registry-embedded</artifactId>
+                    <groupId>com.github.mvallim</groupId>
+                    <version>1.0.0</version>
+                    <unpack>false</unpack>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.bazaarvoice.maven.plugins</groupId>
+                <artifactId>process-exec-maven-plugin</artifactId>
+                <version>0.4</version>
+                <executions>
+                    <execution>
+                        <id>cleanup-test</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>stop-all</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>start-jar</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                        <configuration>
+                            <name>schemaReg</name>
+                            <arguments>
+                                <argument>java</argument>
+                                <argument>-jar</argument>
+                                <argument>-Xms64m</argument>
+                                <argument>-Xmx128m</argument>
+                                <argument>spring-schema-registry-embedded-1.0.0.jar</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-test</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>stop-all</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- the Maven Scala plugin will compile Scala source files -->
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/src/test/scala/za/co/absa/abris/avro/endtoend/FullSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/endtoend/FullSpec.scala
@@ -1,0 +1,56 @@
+package za.co.absa.abris.avro.endtoend
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.execution.streaming.MemoryStream
+import org.apache.spark.sql.functions.struct
+import org.scalatest.FlatSpec
+import za.co.absa.abris.avro.functions.to_avro
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.config.AbrisConfig
+import za.co.absa.abris.examples.ConfluentKafkaAvroWriter.kafkaTopicName
+
+import java.net.Socket
+import java.nio.charset.StandardCharsets
+
+case class SimulatedKakfaRow(key: Array[Byte], value: Array[Byte])
+class FullSpec extends FlatSpec {
+
+  it should "work end to end" in {
+    assume(hostPortInUse("localhost", 8081))
+    val spark = SparkSession.builder().appName("end2end").master("local[1]").getOrCreate()
+    implicit val ctx = spark.sqlContext
+    import spark.implicits._
+    val events = MemoryStream[SimulatedKakfaRow]
+    events.addData(SimulatedKakfaRow("key".getBytes(StandardCharsets.UTF_8),
+    """{"a":"b", "c", 1} """.getBytes(StandardCharsets.UTF_8)))
+
+    val dataFrame = events.toDF()
+    val allColumns = struct(dataFrame.columns.head, dataFrame.columns.tail: _*)
+
+    val schema = AvroSchemaUtils.toAvroSchema(dataFrame)
+    val abrisConfig = AbrisConfig
+      .toConfluentAvro
+      .provideAndRegisterSchema(schema.toString)
+      .usingTopicNameStrategy(kafkaTopicName)
+      .usingSchemaRegistry("http://localhost:8081")
+
+    val avroFrame = dataFrame.select(to_avro(allColumns, abrisConfig) as 'value)
+
+    avroFrame
+      .write
+      .format("kafka")
+      .option("kafka.bootstrap.servers", "localhost:9092")
+      .option("topic", kafkaTopicName)
+      .save()
+
+
+
+  }
+
+  def hostPortInUse(host: String, port: Int): Boolean = {
+    scala.util.Try[Boolean] {
+      new Socket(host, port).close()
+      true
+    }.getOrElse(false)
+  }
+}


### PR DESCRIPTION
So this is a way to move the "examples" to actually working end to end. It is a real PITA to try to get schema registry classpath in this classpath and this embedded tool does it nice. But maybe testcontainers would be easier.