### PR TITLE
Abris #239 part 1 - Upgrade Confluent platform to 6.2.1 and Avro to 1.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,11 @@
         <!--Platforms-->
         <spark.version>2.4.4</spark.version>
         <kafka.spark.version>0-10</kafka.spark.version>
-        <confluent.version>5.3.4</confluent.version>
+        <confluent.version>6.2.1</confluent.version>
 
         <!--Libs-->
         <spark.avro.version>2.4.6</spark.avro.version>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.10.2</avro.version>
 
         <scm.url><!-- defined outside the pom --></scm.url>
         <scm.connection><!-- defined outside the pom --></scm.connection>

--- a/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.serializers.subject.{RecordNameStrategy, TopicNameStrategy, TopicRecordNameStrategy}
 import org.apache.avro.Schema
 
@@ -52,7 +53,7 @@ object SchemaSubject{
   }
 
   def usingRecordNameStrategy(
-    schema: Schema
+    schema: AvroSchema
   ): SchemaSubject = {
     new SchemaSubject(RECORD_NAME_STRATEGY.subjectName("", false, schema))
   }
@@ -68,11 +69,11 @@ object SchemaSubject{
 
   def usingTopicRecordNameStrategy(
     topicName: String,
-    schema: Schema
+    schema: AvroSchema
   ): SchemaSubject = {
     new SchemaSubject(TOPIC_RECORD_NAME_STRATEGY.subjectName(topicName, false, schema))
   }
 
   private def createDummySchema(name: String, namespace: String) =
-    Schema.createRecord(name, "", namespace, false)
+    new AvroSchema(Schema.createRecord(name, "", namespace, false))
 }

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.config
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._
@@ -113,12 +114,12 @@ class ToConfluentAvroRegistrationStrategyConfigFragment(schema: String, confluen
 
   def usingRecordNameStrategy(
   ): ToSchemaRegisteringConfigFragment =
-    toSRCFragment(SchemaSubject.usingRecordNameStrategy(AvroSchemaUtils.parse(schema)))
+    toSRCFragment(SchemaSubject.usingRecordNameStrategy(new AvroSchema(schema)))
 
   def usingTopicRecordNameStrategy(
     topicName: String
   ): ToSchemaRegisteringConfigFragment =
-    toSRCFragment(SchemaSubject.usingTopicRecordNameStrategy(topicName, AvroSchemaUtils.parse(schema)))
+    toSRCFragment(SchemaSubject.usingTopicRecordNameStrategy(topicName, new AvroSchema(schema)))
 
   private def toSRCFragment(subject: SchemaSubject) =
     new ToSchemaRegisteringConfigFragment(subject, schema, confluent)

--- a/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
@@ -16,10 +16,13 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import org.apache.avro.Schema
 
 import java.util
+import java.util.Optional
 
 /**
  * This is a dummy registry that does nothing.
@@ -73,4 +76,22 @@ class MyRegistry(configs: util.Map[String, String]) extends CustomRegistryClient
   override def deleteSchemaVersion(map: util.Map[String, String], s: String, s1: String): Integer = ???
 
   override def reset(): Unit = ???
+
+  override def parseSchema(s: String, s1: String, list: util.List[SchemaReference]): Optional[ParsedSchema] = ???
+
+  override def register(s: String, parsedSchema: ParsedSchema): Int = ???
+
+  override def register(s: String, parsedSchema: ParsedSchema, i: Int, i1: Int): Int = ???
+
+  override def getSchemaById(i: Int): ParsedSchema = ???
+
+  override def getSchemaBySubjectAndId(s: String, i: Int): ParsedSchema = ???
+
+  override def getAllSubjectsById(i: Int): util.Collection[String] = ???
+
+  override def getVersion(s: String, parsedSchema: ParsedSchema): Int = ???
+
+  override def testCompatibility(s: String, parsedSchema: ParsedSchema): Boolean = ???
+
+  override def getId(s: String, parsedSchema: ParsedSchema): Int = ???
 }

--- a/src/test/scala/za/co/absa/abris/avro/registry/SchemaSubjectSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/SchemaSubjectSpec.scala
@@ -16,12 +16,13 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 
 class SchemaSubjectSpec extends FlatSpec with BeforeAndAfter {
 
-  private val schema = AvroSchemaUtils.parse(
+  private val schema = new AvroSchema(
     """{
       |"type": "record",
       |"name": "Blah",


### PR DESCRIPTION
Upgrade to Confluent 6.2.1 and Avro 1.10.2. First part of a fix for #239.

I ran the tests for Spark 3.0 and 3.1 using Scala 2.12 as well as for Spark 2.3 and 2.4 using Scala 2.11 - all green.

My company has had a kafka->spark job running in prod since last week on Spark 3.1, and so far we haven't observed any issues.