### PR TITLE
Abris #239 part 2 - Upgrade to spark 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,11 +77,11 @@
         <!--Platforms-->
         <spark.version>2.4.4</spark.version>
         <kafka.spark.version>0-10</kafka.spark.version>
-        <confluent.version>5.3.4</confluent.version>
+        <confluent.version>6.2.1</confluent.version>
 
         <!--Libs-->
         <spark.avro.version>2.4.6</spark.avro.version>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.10.2</avro.version>
 
         <scm.url><!-- defined outside the pom --></scm.url>
         <scm.connection><!-- defined outside the pom --></scm.connection>

--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
         <spark-24.version>2.4.8</spark-24.version>
         <spark-30.version>3.0.3</spark-30.version>
         <spark-31.version>3.1.2</spark-31.version>
+        <spark-32.version>3.2.0</spark-32.version>
 
-
-        <spark.version>${spark-24.version}</spark.version>
+        <spark.version>${spark-32.version}</spark.version>
 
         <!-- Cross build properties -->
 
@@ -75,7 +75,7 @@
         <scala.maven.plugin.version>3.3.2</scala.maven.plugin.version>
 
         <!--Platforms-->
-        <spark.version>2.4.4</spark.version>
+        <spark.version>3.2.0</spark.version>
         <kafka.spark.version>0-10</kafka.spark.version>
         <confluent.version>6.2.1</confluent.version>
 
@@ -173,6 +173,11 @@
                     <!-- use the jackson libraries specified by Spark sql -->
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- use the jackson libraries specified by Spark sql -->
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -349,6 +354,12 @@
             <id>spark-3.1</id>
             <properties>
                 <spark.version>${spark-31.version}</spark.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>spark-3.2</id>
+            <properties>
+                <spark.version>${spark-32.version}</spark.version>
             </properties>
         </profile>
 

--- a/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/SchemaSubject.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import io.confluent.kafka.serializers.subject.{RecordNameStrategy, TopicNameStrategy, TopicRecordNameStrategy}
 import org.apache.avro.Schema
 
@@ -52,7 +53,7 @@ object SchemaSubject{
   }
 
   def usingRecordNameStrategy(
-    schema: Schema
+    schema: AvroSchema
   ): SchemaSubject = {
     new SchemaSubject(RECORD_NAME_STRATEGY.subjectName("", false, schema))
   }
@@ -68,11 +69,11 @@ object SchemaSubject{
 
   def usingTopicRecordNameStrategy(
     topicName: String,
-    schema: Schema
+    schema: AvroSchema
   ): SchemaSubject = {
     new SchemaSubject(TOPIC_RECORD_NAME_STRATEGY.subjectName(topicName, false, schema))
   }
 
   private def createDummySchema(name: String, namespace: String) =
-    Schema.createRecord(name, "", namespace, false)
+    new AvroSchema(Schema.createRecord(name, "", namespace, false))
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -159,4 +159,7 @@ private[abris] case class AvroDataToCatalyst(
     result = vanillaReader.read(result, decoder)
     result
   }
+
+  override protected def withNewChildInternal(newChild: Expression): AvroDataToCatalyst =
+    copy(child = newChild)
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDeserializer.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDeserializer.scala
@@ -108,7 +108,7 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
           // For backward compatibility, if the Avro type is Long and it is not logical type,
           // the value is processed as timestamp type with millisecond precision.
           updater.setLong(ordinal, value.asInstanceOf[Long] * 1000)
-        case other => throw new IncompatibleSchemaException(
+        case other => throw new scala.Exception(
           s"Cannot convert Avro logical type ${other} to Catalyst Timestamp type.")
       }
 
@@ -276,7 +276,7 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
                     }
 
                   case _ =>
-                    throw new IncompatibleSchemaException(
+                    throw new scala.Exception(
                       s"Cannot convert Avro to catalyst because schema at path " +
                         s"${path.mkString(".")} is not compatible " +
                         s"(avroType = $avroType, sqlType = $catalystType).\n" +
@@ -290,7 +290,7 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
         }
 
       case _ =>
-        throw new IncompatibleSchemaException(
+        throw new scala.Exception(
           s"Cannot convert Avro to catalyst because schema at path ${path.mkString(".")} " +
             s"is not compatible (avroType = $avroType, sqlType = $catalystType).\n" +
             s"Source Avro schema: $rootAvroType.\n" +
@@ -334,7 +334,7 @@ class AvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
         }
         fieldWriters += fieldWriter
       } else if (!sqlField.nullable) {
-        throw new IncompatibleSchemaException(
+        throw new scala.Exception(
           s"""
              |Cannot find non-nullable field ${path.mkString(".")}.${sqlField.name} in Avro schema.
              |Source Avro schema: $rootAvroType.

--- a/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/CatalystDataToAvro.scala
@@ -70,4 +70,7 @@ private[abris] case class CatalystDataToAvro(
     defineCodeGen(ctx, ev, input =>
       s"(byte[]) $expr.nullSafeEval($input)")
   }
+
+  override protected def withNewChildInternal(newChild: Expression): CatalystDataToAvro =
+    copy(child = newChild)
 }

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.config
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._
@@ -113,12 +114,12 @@ class ToConfluentAvroRegistrationStrategyConfigFragment(schema: String, confluen
 
   def usingRecordNameStrategy(
   ): ToSchemaRegisteringConfigFragment =
-    toSRCFragment(SchemaSubject.usingRecordNameStrategy(AvroSchemaUtils.parse(schema)))
+    toSRCFragment(SchemaSubject.usingRecordNameStrategy(new AvroSchema(schema)))
 
   def usingTopicRecordNameStrategy(
     topicName: String
   ): ToSchemaRegisteringConfigFragment =
-    toSRCFragment(SchemaSubject.usingTopicRecordNameStrategy(topicName, AvroSchemaUtils.parse(schema)))
+    toSRCFragment(SchemaSubject.usingTopicRecordNameStrategy(topicName, new AvroSchema(schema)))
 
   private def toSRCFragment(subject: SchemaSubject) =
     new ToSchemaRegisteringConfigFragment(subject, schema, confluent)

--- a/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/MyRegistry.scala
@@ -16,10 +16,13 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.ParsedSchema
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
 import org.apache.avro.Schema
 
 import java.util
+import java.util.Optional
 
 /**
  * This is a dummy registry that does nothing.
@@ -73,4 +76,22 @@ class MyRegistry(configs: util.Map[String, String]) extends CustomRegistryClient
   override def deleteSchemaVersion(map: util.Map[String, String], s: String, s1: String): Integer = ???
 
   override def reset(): Unit = ???
+
+  override def parseSchema(s: String, s1: String, list: util.List[SchemaReference]): Optional[ParsedSchema] = ???
+
+  override def register(s: String, parsedSchema: ParsedSchema): Int = ???
+
+  override def register(s: String, parsedSchema: ParsedSchema, i: Int, i1: Int): Int = ???
+
+  override def getSchemaById(i: Int): ParsedSchema = ???
+
+  override def getSchemaBySubjectAndId(s: String, i: Int): ParsedSchema = ???
+
+  override def getAllSubjectsById(i: Int): util.Collection[String] = ???
+
+  override def getVersion(s: String, parsedSchema: ParsedSchema): Int = ???
+
+  override def testCompatibility(s: String, parsedSchema: ParsedSchema): Boolean = ???
+
+  override def getId(s: String, parsedSchema: ParsedSchema): Int = ???
 }

--- a/src/test/scala/za/co/absa/abris/avro/registry/SchemaSubjectSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/registry/SchemaSubjectSpec.scala
@@ -16,12 +16,13 @@
 
 package za.co.absa.abris.avro.registry
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema
 import org.scalatest.{BeforeAndAfter, FlatSpec}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 
 class SchemaSubjectSpec extends FlatSpec with BeforeAndAfter {
 
-  private val schema = AvroSchemaUtils.parse(
+  private val schema = new AvroSchema(
     """{
       |"type": "record",
       |"name": "Blah",


### PR DESCRIPTION
Upgrade to Spark 3.2.0. Second part of a fix for #239.

This PR builds on top of the changes already requested in PR #244. Since the Spark upgrade fails without those changes, I have included them in this PR too, in order to be able to check out the changes and run tests. If you prefer to have just the Spark change in this PR, let me know and I'll remove the commits from #244.

Currently, the changes suggested only works for Spark 3.2. Due to changes in Spark, the `AvroDataToCatalyst` and `CatalystDataToAvro` classes needs to override a new `withNewChildInternal` method, which becomes an issue when simultaneously supporting Spark 3.2 and older versions: Spark 3.2 compilation will fail and require the Catalyst classes to be abstract without, and 3.1 and older will fail because the new method isn't overriding anything. There might be an elegant way to solve this with traits or similar, but with my limited Scala experience I haven't managed to. This would likely be a decider for whether Spark 3.2 support needs to be maintained in a separate branch or not.

`AvroDeserializer` contains some throws of a generic `scala.Exception` instead of `IncompatibleSchemaException`, since that one is not longer accessible. It's not great, but once #240 is merged the ABRiS `AvroDeserializer` will be replaced with the one from Spark, so that is either fine or these changes can be piggybacked with #240.

I have run tests for Spark 3.2 and Scala 2.12 and they are green. I haven't tested Scala 2.11, since Spark 3.2 does not support support it (and all the older Spark versions obviously fail due to `withNewChildInternal` not overriding anything).