### PR TITLE
Make schema converter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,40 @@ val sqlSchema = new StructType(new StructField ....
 val avroSchema = SparkAvroConversions.toAvroSchema(sqlSchema, avro_schema_name, avro_schema_namespace)
 ```
 
+#### Custom data conversions
+If you would like to use custom logic to convert from Avro to Spark, you can implement the `SchemaConverter` trait.
+The custom class is loaded in ABRiS using the service provider interface (SPI), so you need to register your class in your
+`META-INF/services` resource directory. You can then configure the custom class with its short name or the fully qualified name.
+
+**Example**
+
+Custom schema converter implementation
+```scala
+package za.co.absa.abris.avro.sql
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.DataType
+
+class CustomSchemaConverter extends SchemaConverter {
+  override val shortName: String = "custom"
+  override def toSqlType(avroSchema: Schema): DataType = ???
+}
+```
+
+Provider configuration file `META-INF/services/za.co.absa.abris.avro.sql.SchemaConverter`:
+```
+za.co.absa.abris.avro.sql.CustomSchemaConverter
+```
+
+Abris configuration
+```scala
+val abrisConfig = AbrisConfig
+  .fromConfluentAvro
+  .downloadReaderSchemaByLatestVersion
+  .andTopicNameStrategy("topic123")
+  .usingSchemaRegistry(registryConfig)
+  .withSchemaConverter("custom")
+```
+
 ## Multiple schemas in one topic
 The naming strategies RecordName and TopicRecordName allow for a one topic to receive different payloads, 
 i.e. payloads containing different schemas that do not have to be compatible, 

--- a/src/main/resources/META-INF/services/za.co.absa.abris.avro.sql.SchemaConverter
+++ b/src/main/resources/META-INF/services/za.co.absa.abris.avro.sql.SchemaConverter
@@ -1,0 +1,16 @@
+#
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+za.co.absa.abris.avro.sql.DefaultSchemaConverter

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -175,7 +175,7 @@ private[abris] case class AvroDataToCatalyst(
     import scala.collection.JavaConverters._
     nameOpt match {
       case Some(name) => ServiceLoader.load(classOf[SchemaConverter]).asScala
-        .find(c => c.shortName == name || c.getClass.getSimpleName == name || c.getClass.getName == name)
+        .find(c => c.shortName == name || c.getClass.getName == name)
         .getOrElse(throw new ClassNotFoundException(s"Could not find schema converter $name"))
       case None => new DefaultSchemaConverter()
     }

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -29,6 +29,7 @@ import za.co.absa.abris.avro.read.confluent.{ConfluentConstants, SchemaManagerFa
 import za.co.absa.abris.config.InternalFromAvroConfig
 
 import java.nio.ByteBuffer
+import java.util.ServiceLoader
 import scala.collection.mutable
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
@@ -39,12 +40,11 @@ private[abris] case class AvroDataToCatalyst(
   schemaRegistryConf: Option[Map[String,String]]
 ) extends UnaryExpression with ExpectsInputTypes {
 
-  private val schemaConverter = config.schemaConverter
-    .getOrElse((schema: Schema) => SchemaConverters.toSqlType(schema).dataType)
+  private val schemaConverter = loadSchemaConverter(config.schemaConverter)
 
   override def inputTypes: Seq[BinaryType.type] = Seq(BinaryType)
 
-  override lazy val dataType: DataType = schemaConverter(readerSchema)
+  override lazy val dataType: DataType = schemaConverter.toSqlType(readerSchema)
 
   override def nullable: Boolean = true
 
@@ -171,4 +171,13 @@ private[abris] case class AvroDataToCatalyst(
   override protected def withNewChildInternal(newChild: Expression): Expression =
     copy(child = newChild)
 
+  private def loadSchemaConverter(nameOpt: Option[String]) = {
+    import scala.collection.JavaConverters._
+    nameOpt match {
+      case Some(name) => ServiceLoader.load(classOf[SchemaConverter]).asScala
+        .find(c => c.shortName == name || c.getClass.getSimpleName == name || c.getClass.getName == name)
+        .getOrElse(throw new ClassNotFoundException(s"Could not find schema converter $name"))
+      case None => new DefaultSchemaConverter()
+    }
+  }
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -39,9 +39,12 @@ private[abris] case class AvroDataToCatalyst(
   schemaRegistryConf: Option[Map[String,String]]
 ) extends UnaryExpression with ExpectsInputTypes {
 
+  private val schemaConverter = config.schemaConverter
+    .getOrElse((schema: Schema) => SchemaConverters.toSqlType(schema).dataType)
+
   override def inputTypes: Seq[BinaryType.type] = Seq(BinaryType)
 
-  override lazy val dataType: DataType = SchemaConverters.toSqlType(readerSchema).dataType
+  override lazy val dataType: DataType = schemaConverter(readerSchema)
 
   override def nullable: Boolean = true
 

--- a/src/main/scala/za/co/absa/abris/avro/sql/DefaultSchemaConverter.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/DefaultSchemaConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ABSA Group Limited
+ * Copyright 2022 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package za.co.absa.abris.config
-
+package za.co.absa.abris.avro.sql
 import org.apache.avro.Schema
+import org.apache.spark.sql.avro.SchemaConverters
 import org.apache.spark.sql.types.DataType
-import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
-import za.co.absa.abris.config.FromAvroConfig.Key
 
-private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
-
-  val readerSchema: Schema = AvroSchemaUtils.parse(map(Key.ReaderSchema).asInstanceOf[String])
-
-  val writerSchema: Option[Schema] = map
-    .get(Key.WriterSchema)
-    .map(s => AvroSchemaUtils.parse(s.asInstanceOf[String]))
-
-  val schemaConverter: Option[String] = map
-    .get(Key.SchemaConverter)
-    .map(_.asInstanceOf[String])
+class DefaultSchemaConverter extends SchemaConverter {
+  override val shortName: String = "default"
+  override def toSqlType(avroSchema: Schema): DataType = SchemaConverters.toSqlType(avroSchema).dataType
 }

--- a/src/main/scala/za/co/absa/abris/avro/sql/SchemaConverter.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/SchemaConverter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ABSA Group Limited
+ * Copyright 2022 ABSA Group Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,22 +14,12 @@
  * limitations under the License.
  */
 
-package za.co.absa.abris.config
+package za.co.absa.abris.avro.sql
 
 import org.apache.avro.Schema
 import org.apache.spark.sql.types.DataType
-import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
-import za.co.absa.abris.config.FromAvroConfig.Key
 
-private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
-
-  val readerSchema: Schema = AvroSchemaUtils.parse(map(Key.ReaderSchema).asInstanceOf[String])
-
-  val writerSchema: Option[Schema] = map
-    .get(Key.WriterSchema)
-    .map(s => AvroSchemaUtils.parse(s.asInstanceOf[String]))
-
-  val schemaConverter: Option[String] = map
-    .get(Key.SchemaConverter)
-    .map(_.asInstanceOf[String])
+trait SchemaConverter {
+  val shortName: String
+  def toSqlType(avroSchema: Schema): DataType
 }

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,8 +16,6 @@
 
 package za.co.absa.abris.config
 
-import org.apache.avro.Schema
-import org.apache.spark.sql.types.DataType
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -332,7 +332,7 @@ class FromAvroConfig private(
       schemaRegistryConf
     )
 
-  def withSchemaConverter(schemaConverter: Schema => DataType): FromAvroConfig =
+  def withSchemaConverter(schemaConverter: String): FromAvroConfig =
     new FromAvroConfig(
       abrisConfig + (Key.SchemaConverter -> schemaConverter),
       schemaRegistryConf

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,6 +16,8 @@
 
 package za.co.absa.abris.config
 
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.DataType
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._
@@ -330,6 +332,12 @@ class FromAvroConfig private(
       schemaRegistryConf
     )
 
+  def withSchemaConverter(schemaConverter: Schema => DataType): FromAvroConfig =
+    new FromAvroConfig(
+      abrisConfig + (Key.SchemaConverter -> schemaConverter),
+      schemaRegistryConf
+    )
+
   def validate(): Unit = {
     if(!abrisConfig.contains(Key.ReaderSchema)) {
       throw new IllegalArgumentException(s"Missing mandatory config property ${Key.ReaderSchema}")
@@ -346,5 +354,6 @@ object FromAvroConfig {
   private[abris] object Key {
     val ReaderSchema = "readerSchema"
     val WriterSchema = "writerSchema"
+    val SchemaConverter = "schemaConverter"
   }
 }

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,7 +17,6 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
-import org.apache.spark.sql.types.DataType
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,6 +17,7 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
+import org.apache.spark.sql.types.DataType
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 
@@ -27,4 +28,8 @@ private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
   val writerSchema: Option[Schema] = map
     .get(Key.WriterSchema)
     .map(s => AvroSchemaUtils.parse(s.asInstanceOf[String]))
+
+  val schemaConverter: Option[Schema => DataType] = map
+    .get(Key.SchemaConverter)
+    .map(_.asInstanceOf[Schema => DataType])
 }

--- a/src/test/resources/META-INF/services/za.co.absa.abris.avro.sql.SchemaConverter
+++ b/src/test/resources/META-INF/services/za.co.absa.abris.avro.sql.SchemaConverter
@@ -1,0 +1,16 @@
+#
+# Copyright 2022 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+za.co.absa.abris.avro.sql.DummySchemaConverter

--- a/src/test/scala/za/co/absa/abris/avro/sql/AvroDataToCatalystSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/AvroDataToCatalystSpec.scala
@@ -60,7 +60,7 @@ class AvroDataToCatalystSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     column.expr.dataType shouldBe expectedDataType
   }
 
-  it should "use a custom schema converter" in {
+  it should "use a custom schema converter identified by the short name" in {
     val schemaString = TestSchemas.NATIVE_SIMPLE_NESTED_SCHEMA
     val dummyUrl = "dummyUrl"
 
@@ -70,6 +70,21 @@ class AvroDataToCatalystSpec extends AnyFlatSpec with Matchers with BeforeAndAft
         AbrisConfig.SCHEMA_REGISTRY_URL -> dummyUrl
       ))
       .withSchemaConverter(DummySchemaConverter.name)
+
+    val column = from_avro(col("avroBytes"), fromAvroConfig)
+    column.expr.dataType shouldBe DummySchemaConverter.dataType
+  }
+
+  it should "use a custom schema converter identified by the fully qualified name" in {
+    val schemaString = TestSchemas.NATIVE_SIMPLE_NESTED_SCHEMA
+    val dummyUrl = "dummyUrl"
+
+    val fromAvroConfig = FromAvroConfig()
+      .withReaderSchema(schemaString)
+      .withSchemaRegistryConfig(Map(
+        AbrisConfig.SCHEMA_REGISTRY_URL -> dummyUrl
+      ))
+      .withSchemaConverter("za.co.absa.abris.avro.sql.DummySchemaConverter")
 
     val column = from_avro(col("avroBytes"), fromAvroConfig)
     column.expr.dataType shouldBe DummySchemaConverter.dataType

--- a/src/test/scala/za/co/absa/abris/avro/sql/DummySchemaConverter.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/DummySchemaConverter.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.sql
+
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.{DataType, LongType, StructField, StructType}
+import za.co.absa.abris.avro.sql.DummySchemaConverter._
+
+class DummySchemaConverter extends SchemaConverter {
+  override val shortName: String = name
+  override def toSqlType(avroSchema: Schema): DataType = dataType
+}
+
+object DummySchemaConverter {
+  val name: String = "dummy"
+  val dataType: DataType = StructType(Seq(StructField("long", LongType)))
+}

--- a/src/test/scala/za/co/absa/abris/config/FromAvroConfigSpec.scala
+++ b/src/test/scala/za/co/absa/abris/config/FromAvroConfigSpec.scala
@@ -16,6 +16,8 @@
 
 package za.co.absa.abris.config
 
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.LongType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.abris.config.FromAvroConfig.Key
@@ -25,14 +27,17 @@ class FromAvroConfigSpec extends AnyFlatSpec with Matchers {
   behavior of "FromAvroConfig"
 
   it should "provide all set configurations" in {
+    val dummySchemaConverter = (_: Schema) => LongType
     val config = FromAvroConfig()
       .withWriterSchema("foo")
       .withReaderSchema("bar")
+      .withSchemaConverter(dummySchemaConverter)
       .withSchemaRegistryConfig(Map(AbrisConfig.SCHEMA_REGISTRY_URL -> "url"))
 
     val map = config.abrisConfig()
     map(Key.WriterSchema) shouldBe "foo"
     map(Key.ReaderSchema) shouldBe "bar"
+    map(Key.SchemaConverter) shouldBe dummySchemaConverter
 
     config.schemaRegistryConf().get(AbrisConfig.SCHEMA_REGISTRY_URL) shouldBe "url"
   }

--- a/src/test/scala/za/co/absa/abris/config/FromAvroConfigSpec.scala
+++ b/src/test/scala/za/co/absa/abris/config/FromAvroConfigSpec.scala
@@ -16,8 +16,6 @@
 
 package za.co.absa.abris.config
 
-import org.apache.avro.Schema
-import org.apache.spark.sql.types.LongType
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.abris.config.FromAvroConfig.Key
@@ -27,7 +25,7 @@ class FromAvroConfigSpec extends AnyFlatSpec with Matchers {
   behavior of "FromAvroConfig"
 
   it should "provide all set configurations" in {
-    val dummySchemaConverter = (_: Schema) => LongType
+    val dummySchemaConverter = "dummy"
     val config = FromAvroConfig()
       .withWriterSchema("foo")
       .withReaderSchema("bar")


### PR DESCRIPTION
## Background
Currently, [SchemaConverters](https://github.com/apache/spark/blob/v3.2.1/external/avro/src/main/scala/org/apache/spark/sql/avro/SchemaConverters.scala#L54) is used in [AvroDataToCatalyst](https://github.com/AbsaOSS/ABRiS/blob/v6.0.0/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala#L44) to convert an Avro schema to a Spark data type.

I have a workload that reads from a Kafka topic, adds / transforms some columns, and then writes that data back to another Kafka topic. The schema for the target Kafka topic is auto-generated (based on the Spark schema) and is registered outside ABRiS. The source schema contains default values that should be kept for the target schema, but with the SchemaConverters implementation, these default values are lost. Furthermore, some type conversions from Avro to Spark are not bijective, e.g. Avro types `BYTES` and `FIXED` are both converted to `DecimalType` (if their Avro logical type is `Decimal`) or both to `BinaryType` (if they have no Avro logical type). Without the original logical type, it is impossible to decide whether `DecimalType` should be converted back to `BYTES` or `FIXED`. The `SchemaConverters` implementation chooses `FIXED`. This is undesirable if the source schema needs to be preserved for whatever reason. The same problem exists for Spark type `TimestampType` which is always converted to Avro type Long / `TimestampMicros`, but it could as well be Long / `TimestampMillis`.

One solution to these problems is to store the extra information from the Avro schema to column metadata in Spark (`StructField` metadata, to be precise). However, to do this, a custom schema conversion is required.

## Feature
The `SchemaConverters` implementation may work for most use-cases, but there are scenarios in which a user wishes to convert an Avro schema in a custom way, e.g. writing default values into Spark metadata. Thus, I suggest making the schema conversion configurable, where a user can optionally pass a function `Schema => DataType` to the From Avro Config. The default is `(schema: Schema) => SchemaConverters.toSqlType(schema).dataType`

## Other
This functionality should be backported to ABRiS v5 as well.