### PR TITLE
Implement error handling mods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,13 @@
             <version>1.0.0</version>
         </dependency>
 
+        <!-- Other -->
+        <dependency>
+            <groupId>za.co.absa.commons</groupId>
+            <artifactId>commons_${scala.compat.version}</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.spark.SparkException
+
+class DefaultExceptionHandler extends DeserializationExceptionHandler {
+
+  def handle(exception: Throwable) : Any = {
+    throw new SparkException("Malformed records are detected in record parsing.", exception)
+  }
+}

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -19,12 +19,12 @@ package za.co.absa.abris.avro.errors
 
 import org.apache.avro.Schema
 import org.apache.spark.SparkException
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
 import org.apache.spark.sql.types.DataType
-import za.co.absa.abris.avro.sql.AvroDeserializer
 
 class DefaultExceptionHandler extends DeserializationExceptionHandler {
 
-  def handle(exception: Throwable, avroDeserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType) : Any = {
+  def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema, dataType: DataType) : Any = {
     throw new SparkException("Malformed records are detected in record parsing.", exception)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -17,11 +17,14 @@
 
 package za.co.absa.abris.avro.errors
 
+import org.apache.avro.Schema
 import org.apache.spark.SparkException
+import org.apache.spark.sql.types.DataType
+import za.co.absa.abris.avro.sql.AvroDeserializer
 
 class DefaultExceptionHandler extends DeserializationExceptionHandler {
 
-  def handle(exception: Throwable) : Any = {
+  def handle(exception: Throwable, avroDeserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType) : Any = {
     throw new SparkException("Malformed records are detected in record parsing.", exception)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -20,11 +20,10 @@ package za.co.absa.abris.avro.errors
 import org.apache.avro.Schema
 import org.apache.spark.SparkException
 import org.apache.spark.sql.avro.AbrisAvroDeserializer
-import org.apache.spark.sql.types.DataType
 
 class DefaultExceptionHandler extends DeserializationExceptionHandler {
 
-  def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema, dataType: DataType) : Any = {
+  def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
     throw new SparkException("Malformed records are detected in record parsing.", exception)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -24,6 +24,6 @@ import org.apache.spark.sql.avro.AbrisAvroDeserializer
 class DefaultExceptionHandler extends DeserializationExceptionHandler {
 
   def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
-    throw new SparkException("Malformed records are detected in record parsing.", exception)
+    throw new SparkException(s"Malformed records are detected in record parsing: ${exception.getMessage}")
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -24,6 +24,6 @@ import org.apache.spark.sql.avro.AbrisAvroDeserializer
 class DefaultExceptionHandler extends DeserializationExceptionHandler {
 
   def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
-    throw new SparkException(s"Malformed records are detected in record parsing: ${exception.getMessage}")
+    throw new SparkException(s"Malformed records are detected in record parsing.", exception)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
@@ -20,7 +20,7 @@ package za.co.absa.abris.avro.errors
 import org.apache.avro.Schema
 import org.apache.spark.sql.avro.AbrisAvroDeserializer
 
-trait DeserializationExceptionHandler {
+trait DeserializationExceptionHandler extends Serializable {
 
   def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any
 

--- a/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
@@ -18,12 +18,10 @@
 package za.co.absa.abris.avro.errors
 
 import org.apache.avro.Schema
-import org.apache.spark.sql.types.DataType
-import za.co.absa.abris.avro.sql.AvroDeserializer
-
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
 
 trait DeserializationExceptionHandler {
 
-  def handle(exception: Throwable, deserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType) : Any
+  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any
 
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
-package za.co.absa.abris.avro.errors;
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.Schema
+import org.apache.spark.sql.types.DataType
+import za.co.absa.abris.avro.sql.AvroDeserializer
+
 
 trait DeserializationExceptionHandler {
 
-  def handle(exception: Throwable) : Any
+  def handle(exception: Throwable, deserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType) : Any
 
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors;
+
+trait DeserializationExceptionHandler {
+
+  def handle(exception: Throwable) : Any
+
+}

--- a/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
@@ -17,14 +17,17 @@
 
 package za.co.absa.abris.avro.errors
 
+import org.apache.avro.Schema
 import org.apache.spark.internal.Logging
-import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.types.DataType
+import za.co.absa.abris.avro.format.ScalaAvroRecord
+import za.co.absa.abris.avro.sql.AvroDeserializer
 
+class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
 
-class NullExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
-
-  def handle(exception: Throwable): Any = {
-    logInfo("NullExceptionHandler", exception)
-    InternalRow.fromSeq(Seq("error"))
+  def handle(exception: Throwable, deserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType): Any = {
+    logWarning("NullExceptionHandler", exception)
+    deserializer.deserialize(new ScalaAvroRecord(readerSchema))
+    logWarning("successfully handle exception")
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
@@ -22,12 +22,11 @@ import org.apache.avro.generic.GenericData.Record
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.avro.AbrisAvroDeserializer
 
-class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
+class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging {
 
   def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
     logWarning("EmptyExceptionHandler", exception)
     val emptyRecord = new Record(readerSchema)
-    val emptyRow = deserializer.deserialize(emptyRecord)
-    emptyRow
+    deserializer.deserialize(emptyRecord)
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
@@ -18,14 +18,14 @@
 package za.co.absa.abris.avro.errors
 
 import org.apache.avro.Schema
+import org.apache.avro.hadoop.io.AvroDeserializer
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
 import org.apache.spark.sql.types.DataType
-import za.co.absa.abris.avro.format.ScalaAvroRecord
-import za.co.absa.abris.avro.sql.AvroDeserializer
 
 class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
 
-  def handle(exception: Throwable, deserializer: AvroDeserializer, readerSchema: Schema, dataType: DataType): Any = {
+  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema, dataType: DataType): Any = {
     logWarning("NullExceptionHandler", exception)
     deserializer.deserialize(new ScalaAvroRecord(readerSchema))
     logWarning("successfully handle exception")

--- a/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
@@ -18,16 +18,16 @@
 package za.co.absa.abris.avro.errors
 
 import org.apache.avro.Schema
-import org.apache.avro.hadoop.io.AvroDeserializer
+import org.apache.avro.generic.GenericData.Record
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.avro.AbrisAvroDeserializer
-import org.apache.spark.sql.types.DataType
 
 class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
 
-  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema, dataType: DataType): Any = {
-    logWarning("NullExceptionHandler", exception)
-    deserializer.deserialize(new ScalaAvroRecord(readerSchema))
-    logWarning("successfully handle exception")
+  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
+    logWarning("EmptyExceptionHandler", exception)
+    val emptyRecord = new Record(readerSchema)
+    val emptyRow = deserializer.deserialize(emptyRecord)
+    emptyRow
   }
 }

--- a/src/main/scala/za/co/absa/abris/avro/errors/NullExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/NullExceptionHandler.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.catalyst.InternalRow
+
+
+class NullExceptionHandler extends DeserializationExceptionHandler with Logging with Serializable {
+
+  def handle(exception: Throwable): Any = {
+    logInfo("NullExceptionHandler", exception)
+    InternalRow.fromSeq(Seq("error"))
+  }
+}

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -20,11 +20,12 @@ import org.apache.avro.Schema
 import org.apache.avro.generic.GenericDatumReader
 import org.apache.avro.io.{BinaryDecoder, DecoderFactory}
 import org.apache.kafka.common.errors.SerializationException
-import org.apache.spark.SparkException
+import org.apache.spark.internal.Logging
 import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, UnaryExpression}
 import org.apache.spark.sql.types.{BinaryType, DataType}
+import za.co.absa.abris.avro.errors.DeserializationExceptionHandler
 import za.co.absa.abris.avro.read.confluent.{ConfluentConstants, SchemaManagerFactory}
 import za.co.absa.abris.config.InternalFromAvroConfig
 
@@ -35,10 +36,10 @@ import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 
 private[abris] case class AvroDataToCatalyst(
-  child: Expression,
-  abrisConfig: Map[String,Any],
-  schemaRegistryConf: Option[Map[String,String]]
-) extends UnaryExpression with ExpectsInputTypes {
+                                              child: Expression,
+                                              abrisConfig: Map[String, Any],
+                                              schemaRegistryConf: Option[Map[String, String]]
+                                            ) extends UnaryExpression with ExpectsInputTypes with Logging {
 
   @transient private lazy val schemaConverter = loadSchemaConverter(config.schemaConverter)
 
@@ -57,6 +58,8 @@ private[abris] case class AvroDataToCatalyst(
   @transient private lazy val readerSchema = config.readerSchema
 
   @transient private lazy val writerSchemaOption = config.writerSchema
+
+  @transient private lazy val deserializationHandler: DeserializationExceptionHandler = config.deserializationHandler
 
   @transient private lazy val vanillaReader: GenericDatumReader[Any] =
     new GenericDatumReader[Any](writerSchemaOption.getOrElse(readerSchema), readerSchema)
@@ -82,8 +85,7 @@ private[abris] case class AvroDataToCatalyst(
       // There could be multiple possible exceptions here, e.g. java.io.IOException,
       // AvroRuntimeException, ArrayIndexOutOfBoundsException, etc.
       // To make it simple, catch all the exceptions here.
-//      case NonFatal(e) =>  throw new SparkException("Malformed records are detected in record parsing.", e)
-      case NonFatal(e) => deserializationHandler.handle(e, deserializer, readerSchema, dataType)
+      case NonFatal(e) => deserializationHandler.handle(e, deserializer, readerSchema)
     }
   }
 

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
 import org.apache.spark.sql.catalyst.expressions.codegen.{CodeGenerator, CodegenContext, ExprCode}
 import org.apache.spark.sql.catalyst.expressions.{ExpectsInputTypes, Expression, UnaryExpression}
 import org.apache.spark.sql.types.{BinaryType, DataType}
-import za.co.absa.abris.avro.errors.DeserializationExceptionHandler
 import za.co.absa.abris.avro.read.confluent.{ConfluentConstants, SchemaManagerFactory}
 import za.co.absa.abris.config.InternalFromAvroConfig
 
@@ -58,8 +57,6 @@ private[abris] case class AvroDataToCatalyst(
   @transient private lazy val readerSchema = config.readerSchema
 
   @transient private lazy val writerSchemaOption = config.writerSchema
-
-  @transient private lazy val deserializationHandler: DeserializationExceptionHandler = config.deserializationHandler
 
   @transient private lazy val vanillaReader: GenericDatumReader[Any] =
     new GenericDatumReader[Any](writerSchemaOption.getOrElse(readerSchema), readerSchema)

--- a/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
+++ b/src/main/scala/za/co/absa/abris/avro/sql/AvroDataToCatalyst.scala
@@ -86,7 +86,7 @@ private[abris] case class AvroDataToCatalyst(
       // AvroRuntimeException, ArrayIndexOutOfBoundsException, etc.
       // To make it simple, catch all the exceptions here.
 //      case NonFatal(e) =>  throw new SparkException("Malformed records are detected in record parsing.", e)
-      case NonFatal(e) => deserializationHandler.handle(e)
+      case NonFatal(e) => deserializationHandler.handle(e, deserializer, readerSchema, dataType)
     }
   }
 

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.config
 
+import za.co.absa.abris.avro.errors.DeserializationExceptionHandler
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._
@@ -336,6 +337,15 @@ class FromAvroConfig private(
       schemaRegistryConf
     )
 
+  /**
+   * @param exceptionHandler exception handler used for converting from avro
+   */
+  def withExceptionHandler(exceptionHandler: DeserializationExceptionHandler): FromAvroConfig =
+    new FromAvroConfig(
+      abrisConfig + (Key.ExceptionHandler -> exceptionHandler),
+      schemaRegistryConf
+    )
+
   def validate(): Unit = {
     if(!abrisConfig.contains(Key.ReaderSchema)) {
       throw new IllegalArgumentException(s"Missing mandatory config property ${Key.ReaderSchema}")
@@ -353,5 +363,6 @@ object FromAvroConfig {
     val ReaderSchema = "readerSchema"
     val WriterSchema = "writerSchema"
     val SchemaConverter = "schemaConverter"
+    val ExceptionHandler = "exceptionHandler"
   }
 }

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,6 +17,7 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
+import za.co.absa.abris.avro.errors.{DeserializationExceptionHandler, NullExceptionHandler}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 
@@ -31,4 +32,6 @@ private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
   val schemaConverter: Option[String] = map
     .get(Key.SchemaConverter)
     .map(_.asInstanceOf[String])
+
+  val deserializationHandler: DeserializationExceptionHandler = new NullExceptionHandler
 }

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,7 +17,7 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
-import za.co.absa.abris.avro.errors.{DefaultExceptionHandler, DeserializationExceptionHandler, NullExceptionHandler}
+import za.co.absa.abris.avro.errors.{DefaultExceptionHandler, DeserializationExceptionHandler}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,7 +17,7 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
-import za.co.absa.abris.avro.errors.{DeserializationExceptionHandler, NullExceptionHandler}
+import za.co.absa.abris.avro.errors.{DefaultExceptionHandler, DeserializationExceptionHandler, NullExceptionHandler}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 
@@ -33,5 +33,8 @@ private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
     .get(Key.SchemaConverter)
     .map(_.asInstanceOf[String])
 
-  val deserializationHandler: DeserializationExceptionHandler = new NullExceptionHandler
+  val deserializationHandler: DeserializationExceptionHandler = map
+    .get(Key.ExceptionHandler)
+    .map(s => s.asInstanceOf[DeserializationExceptionHandler])
+    .getOrElse(new DefaultExceptionHandler)
 }

--- a/src/test/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandlerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandlerSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
+import org.apache.spark.sql.types.DataType
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.TestSchemas
+
+
+class DefaultExceptionHandlerSpec extends AnyFlatSpec with Matchers {
+
+  it should "should throw spark exception on error" in {
+
+    val deserializationExceptionHandler = new DefaultExceptionHandler
+    val schema = AvroSchemaUtils.parse(TestSchemas.COMPLEX_SCHEMA_SPEC)
+    val dataType: DataType = SchemaConverters.toSqlType(schema).dataType
+    val deserializer = new AbrisAvroDeserializer(schema, dataType)
+
+    an[SparkException] should be thrownBy (deserializationExceptionHandler.handle(new Exception, deserializer, schema))
+    val exceptionThrown = the[SparkException] thrownBy (deserializationExceptionHandler.handle(new Exception, deserializer, schema))
+    exceptionThrown.getMessage should equal("Malformed records are detected in record parsing.")
+  }
+}

--- a/src/test/scala/za/co/absa/abris/avro/errors/ExceptionHandlerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/errors/ExceptionHandlerSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.generic.GenericData.Record
+import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
+import org.apache.spark.sql.types.DataType
+import org.scalatest.flatspec.AnyFlatSpec
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.TestSchemas
+
+class ExceptionHandlerSpec extends AnyFlatSpec {
+
+  it should "receive empty dataframe row back" in {
+    val deserializationExceptionHandler = new EmptyExceptionHandler
+    val schema = AvroSchemaUtils.parse(TestSchemas.COMPLEX_SCHEMA_SPEC)
+    val dataType: DataType = SchemaConverters.toSqlType(schema).dataType
+    val deserializer = new AbrisAvroDeserializer(schema, dataType)
+    val expectedEmptyRecord = deserializer.deserialize(new Record(schema))
+
+    assert(deserializationExceptionHandler.handle(
+      new Exception, new AbrisAvroDeserializer(schema, dataType), schema) == expectedEmptyRecord)
+  }
+}

--- a/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
@@ -27,6 +27,7 @@ import za.co.absa.abris.avro.functions._
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry.{ConfluentMockRegistryClient, SchemaSubject}
+import za.co.absa.abris.avro.utils.AvroSchemaEncoder
 import za.co.absa.abris.config.AbrisConfig
 import za.co.absa.abris.examples.data.generation.{ComplexRecordsGenerator, TestSchemas}
 
@@ -42,7 +43,8 @@ class CatalystAvroConversionSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   import spark.implicits._
 
-  implicit val encoder: Encoder[Row] = getEncoder
+  private val avroSchemaEncoder = new AvroSchemaEncoder
+  implicit val encoder: Encoder[Row] = avroSchemaEncoder.getEncoder
 
   private val dummyUrl = "dummyUrl"
   private val schemaRegistryConfig = Map(AbrisConfig.SCHEMA_REGISTRY_URL -> dummyUrl)
@@ -506,11 +508,4 @@ class CatalystAvroConversionSpec extends AnyFlatSpec with Matchers with BeforeAn
 
     shouldEqualByData(dataFrame, result)
   }
-
-  private def getEncoder: Encoder[Row] = {
-    val avroSchema = AvroSchemaUtils.parse(ComplexRecordsGenerator.usedAvroSchema)
-    val sparkSchema = SparkAvroConversions.toSqlType(avroSchema)
-    RowEncoder.apply(sparkSchema)
-  }
-
 }

--- a/src/test/scala/za/co/absa/abris/avro/utils/AvroSchemaEncoder.scala
+++ b/src/test/scala/za/co/absa/abris/avro/utils/AvroSchemaEncoder.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.utils
+
+import org.apache.spark.sql.{Encoder, Row}
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import za.co.absa.abris.avro.format.SparkAvroConversions
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.ComplexRecordsGenerator
+
+class AvroSchemaEncoder {
+
+  def getEncoder: Encoder[Row] = {
+    val avroSchema = AvroSchemaUtils.parse(ComplexRecordsGenerator.usedAvroSchema)
+    val sparkSchema = SparkAvroConversions.toSqlType(avroSchema)
+    RowEncoder.apply(sparkSchema)
+  }
+
+}


### PR DESCRIPTION
Had a use case that required skipping bad messages instead of just failing fast. This adds exception handling functionality to ABRiS so that it can fail fast or fail and return an empty row exactly as described in issue #183.

However, there is an issue that when it runs, the EmptyExceptionHandler's log output occurs many times instead of just once per exception. Currently, the reason for this is unknown and was wondering if there is anything I am missing?