### PR TITLE
adding exception handlers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,13 @@
             <version>1.0.0</version>
         </dependency>
 
+        <!-- Other -->
+        <dependency>
+            <groupId>za.co.absa.commons</groupId>
+            <artifactId>commons_${scala.compat.version}</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandler.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.Schema
+import org.apache.spark.SparkException
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
+
+class DefaultExceptionHandler extends DeserializationExceptionHandler {
+
+  def handle(exception: Throwable, avroDeserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
+    throw new SparkException(s"Malformed records are detected in record parsing.", exception)
+  }
+}

--- a/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/DeserializationExceptionHandler.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.Schema
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
+
+trait DeserializationExceptionHandler extends Serializable {
+
+  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any
+
+}

--- a/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
+++ b/src/main/scala/za/co/absa/abris/avro/errors/EmptyExceptionHandler.scala
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.Schema
+import org.apache.avro.generic.GenericData.Record
+import org.apache.spark.internal.Logging
+import org.apache.spark.sql.avro.AbrisAvroDeserializer
+
+class EmptyExceptionHandler extends DeserializationExceptionHandler with Logging {
+
+  def handle(exception: Throwable, deserializer: AbrisAvroDeserializer, readerSchema: Schema): Any = {
+    logWarning("EmptyExceptionHandler", exception)
+    val emptyRecord = new Record(readerSchema)
+    deserializer.deserialize(emptyRecord)
+  }
+}

--- a/src/main/scala/za/co/absa/abris/config/Config.scala
+++ b/src/main/scala/za/co/absa/abris/config/Config.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.abris.config
 
+import za.co.absa.abris.avro.errors.DeserializationExceptionHandler
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry._
@@ -336,6 +337,15 @@ class FromAvroConfig private(
       schemaRegistryConf
     )
 
+  /**
+   * @param exceptionHandler exception handler used for converting from avro
+   */
+  def withExceptionHandler(exceptionHandler: DeserializationExceptionHandler): FromAvroConfig =
+    new FromAvroConfig(
+      abrisConfig + (Key.ExceptionHandler -> exceptionHandler),
+      schemaRegistryConf
+    )
+
   def validate(): Unit = {
     if(!abrisConfig.contains(Key.ReaderSchema)) {
       throw new IllegalArgumentException(s"Missing mandatory config property ${Key.ReaderSchema}")
@@ -353,5 +363,6 @@ object FromAvroConfig {
     val ReaderSchema = "readerSchema"
     val WriterSchema = "writerSchema"
     val SchemaConverter = "schemaConverter"
+    val ExceptionHandler = "exceptionHandler"
   }
 }

--- a/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
+++ b/src/main/scala/za/co/absa/abris/config/InternalFromAvroConfig.scala
@@ -17,6 +17,7 @@
 package za.co.absa.abris.config
 
 import org.apache.avro.Schema
+import za.co.absa.abris.avro.errors.{DefaultExceptionHandler, DeserializationExceptionHandler}
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.config.FromAvroConfig.Key
 
@@ -31,4 +32,9 @@ private[abris] class InternalFromAvroConfig(map: Map[String, Any]) {
   val schemaConverter: Option[String] = map
     .get(Key.SchemaConverter)
     .map(_.asInstanceOf[String])
+
+  val deserializationHandler: DeserializationExceptionHandler = map
+    .get(Key.ExceptionHandler)
+    .map(s => s.asInstanceOf[DeserializationExceptionHandler])
+    .getOrElse(new DefaultExceptionHandler)
 }

--- a/src/test/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandlerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/errors/DefaultExceptionHandlerSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.spark.SparkException
+import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
+import org.apache.spark.sql.types.DataType
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.TestSchemas
+
+
+class DefaultExceptionHandlerSpec extends AnyFlatSpec with Matchers {
+
+  it should "should throw spark exception on error" in {
+
+    val deserializationExceptionHandler = new DefaultExceptionHandler
+    val schema = AvroSchemaUtils.parse(TestSchemas.COMPLEX_SCHEMA_SPEC)
+    val dataType: DataType = SchemaConverters.toSqlType(schema).dataType
+    val deserializer = new AbrisAvroDeserializer(schema, dataType)
+
+    an[SparkException] should be thrownBy (deserializationExceptionHandler.handle(new Exception, deserializer, schema))
+    val exceptionThrown = the[SparkException] thrownBy (deserializationExceptionHandler.handle(new Exception, deserializer, schema))
+    exceptionThrown.getMessage should equal("Malformed records are detected in record parsing.")
+  }
+}

--- a/src/test/scala/za/co/absa/abris/avro/errors/ExceptionHandlerSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/errors/ExceptionHandlerSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.errors
+
+import org.apache.avro.generic.GenericData.Record
+import org.apache.spark.sql.avro.{AbrisAvroDeserializer, SchemaConverters}
+import org.apache.spark.sql.types.DataType
+import org.scalatest.flatspec.AnyFlatSpec
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.TestSchemas
+
+class ExceptionHandlerSpec extends AnyFlatSpec {
+
+  it should "receive empty dataframe row back" in {
+    val deserializationExceptionHandler = new EmptyExceptionHandler
+    val schema = AvroSchemaUtils.parse(TestSchemas.COMPLEX_SCHEMA_SPEC)
+    val dataType: DataType = SchemaConverters.toSqlType(schema).dataType
+    val deserializer = new AbrisAvroDeserializer(schema, dataType)
+    val expectedEmptyRecord = deserializer.deserialize(new Record(schema))
+
+    assert(deserializationExceptionHandler.handle(
+      new Exception, new AbrisAvroDeserializer(schema, dataType), schema) == expectedEmptyRecord)
+  }
+}

--- a/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/sql/CatalystAvroConversionSpec.scala
@@ -27,6 +27,7 @@ import za.co.absa.abris.avro.functions._
 import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
 import za.co.absa.abris.avro.read.confluent.SchemaManagerFactory
 import za.co.absa.abris.avro.registry.{ConfluentMockRegistryClient, SchemaSubject}
+import za.co.absa.abris.avro.utils.AvroSchemaEncoder
 import za.co.absa.abris.config.AbrisConfig
 import za.co.absa.abris.examples.data.generation.{ComplexRecordsGenerator, TestSchemas}
 
@@ -42,7 +43,8 @@ class CatalystAvroConversionSpec extends AnyFlatSpec with Matchers with BeforeAn
 
   import spark.implicits._
 
-  implicit val encoder: Encoder[Row] = getEncoder
+  private val avroSchemaEncoder = new AvroSchemaEncoder
+  implicit val encoder: Encoder[Row] = avroSchemaEncoder.getEncoder
 
   private val dummyUrl = "dummyUrl"
   private val schemaRegistryConfig = Map(AbrisConfig.SCHEMA_REGISTRY_URL -> dummyUrl)
@@ -506,11 +508,4 @@ class CatalystAvroConversionSpec extends AnyFlatSpec with Matchers with BeforeAn
 
     shouldEqualByData(dataFrame, result)
   }
-
-  private def getEncoder: Encoder[Row] = {
-    val avroSchema = AvroSchemaUtils.parse(ComplexRecordsGenerator.usedAvroSchema)
-    val sparkSchema = SparkAvroConversions.toSqlType(avroSchema)
-    RowEncoder.apply(sparkSchema)
-  }
-
 }

--- a/src/test/scala/za/co/absa/abris/avro/utils/AvroSchemaEncoder.scala
+++ b/src/test/scala/za/co/absa/abris/avro/utils/AvroSchemaEncoder.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.abris.avro.utils
+
+import org.apache.spark.sql.{Encoder, Row}
+import org.apache.spark.sql.catalyst.encoders.RowEncoder
+import za.co.absa.abris.avro.format.SparkAvroConversions
+import za.co.absa.abris.avro.parsing.utils.AvroSchemaUtils
+import za.co.absa.abris.examples.data.generation.ComplexRecordsGenerator
+
+class AvroSchemaEncoder {
+
+  def getEncoder: Encoder[Row] = {
+    val avroSchema = AvroSchemaUtils.parse(ComplexRecordsGenerator.usedAvroSchema)
+    val sparkSchema = SparkAvroConversions.toSqlType(avroSchema)
+    RowEncoder.apply(sparkSchema)
+  }
+
+}


### PR DESCRIPTION
Had a use case that required skipping bad messages instead of just failing fast. This adds exception handling functionality to ABRiS so that it can fail fast or fail and return an empty row exactly as described in issue https://github.com/AbsaOSS/ABRiS/issues/183.

However, there is an issue with the EmptyExceptionHandler's log output occurring many times instead of just once per exception. Currently the reason for this is not known and was wondering if there would be a known solution?