### PR TITLE
Move permissions to job level

### DIFF
--- a/.github/workflows/build-scala2.12-spark3.2.yml
+++ b/.github/workflows/build-scala2.12-spark3.2.yml
@@ -6,15 +6,13 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/.github/workflows/build-scala2.13-spark3.2.yml
+++ b/.github/workflows/build-scala2.13-spark3.2.yml
@@ -6,15 +6,13 @@ on:
   pull_request:
     branches: [ master ]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8


### PR DESCRIPTION
Related to https://github.com/AbsaOSS/ABRiS/pull/328, after reading https://github.com/actions/first-interaction/issues/10 I almost came to the conclusion that granting write permissions for outside contributors simply doesn't work, but I see it works in Spark's repo, e.g. here with the labeler action: https://github.com/apache/spark/actions/runs/5498054282/workflow?pr=41905 The only difference I can see is that the permissions are defined under the job, not on the top-level of the yaml file. Makes no sense, but I'd give it a try anyway.