### PR TITLE
abris #329 use pull_request_target to fix PRs from forks

### DIFF
--- a/.github/workflows/build-scala2.12-spark3.2.yml
+++ b/.github/workflows/build-scala2.12-spark3.2.yml
@@ -3,7 +3,7 @@ name: Build Scala 2.12, Spark 3.2
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/build-scala2.13-spark3.2.yml
+++ b/.github/workflows/build-scala2.13-spark3.2.yml
@@ -3,7 +3,7 @@ name: Build Scala 2.13, Spark 3.2
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION
As I understand it, GitHub considers any fork PR as potentially dangerous. So when using `on pull-request` in action, it will always set all permissions to read.

There is `pull_request_target` that is less safe, but it should allow `write` permission.

So I am switching the action to `pull_request_target` and to mitigate the unsafeness I will also switch settings to **Require approval for all outside collaborators**.

There are other solutions to this that may be better, but also more complicated, if you want to look into it @miroslavpojer @Zejnilovic


For more info, see:
- https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/