### PR TITLE
Use previous versions behaviour as default for new constructor parameter

### DIFF
--- a/src/main/scala/org/apache/spark/sql/avro/AbrisAvroDeserializer.scala
+++ b/src/main/scala/org/apache/spark/sql/avro/AbrisAvroDeserializer.scala
@@ -36,7 +36,10 @@ class AbrisAvroDeserializer(rootAvroType: Schema, rootCatalystType: DataType) {
         .newInstance(rootAvroType, rootCatalystType) // Spark 2.4 -
     }.recover { case _: NoSuchMethodException =>
       clazz.getConstructor(classOf[Schema], classOf[DataType], classOf[String])
-        .newInstance(rootAvroType, rootCatalystType, "LEGACY") // Spark 3.0 +
+        .newInstance(rootAvroType, rootCatalystType, "LEGACY") // Spark 3.0 - Spark 3.5.0 (including)
+    }.recover { case _: NoSuchMethodException =>
+      clazz.getConstructor(classOf[Schema], classOf[DataType], classOf[String], classOf[Boolean])
+        .newInstance(rootAvroType, rootCatalystType, "LEGACY", false: java.lang.Boolean) // Spark 3.5.x +
     }
       .get
       .asInstanceOf[AvroDeserializer]


### PR DESCRIPTION
Closes #352 

Support for the “enableStableIdentifiersForUnionType” option introduced in
https://github.com/apache/spark/pull/41263/ was not added. Instead, the option is set to false, which is the default value as documented in https://spark.apache.org/docs/latest/sql-data-sources-avro.html#data-source-option. Users can still use the feature by providing their own SchemaConverter implementation, as explained in https://github.com/absaoss/abris?tab=readme-ov-file#custom-data-conversions 
If there is demand to directly support this feature through Abris, it can be implemented, but it would require another reflection-based differentiation among Spark versions that support it or not.
