### PR TITLE
Added restService based overload with CachedSchemaRegistryClient

### DIFF
--- a/src/main/scala/za/co/absa/abris/avro/registry/ConfluentRegistryClient.scala
+++ b/src/main/scala/za/co/absa/abris/avro/registry/ConfluentRegistryClient.scala
@@ -15,6 +15,7 @@
  */
 
 package za.co.absa.abris.avro.registry
+import io.confluent.kafka.schemaregistry.client.rest.RestService
 import io.confluent.kafka.schemaregistry.client.{CachedSchemaRegistryClient, SchemaRegistryClient}
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 
@@ -23,6 +24,10 @@ import scala.collection.JavaConverters._
 class ConfluentRegistryClient(client: SchemaRegistryClient) extends AbstractConfluentRegistryClient(client) {
 
   def this(configs: Map[String,String]) = this(ConfluentRegistryClient.createClient(configs))
+
+  def this(restService: RestService, maxSchemaObject: Int) = {
+    this(ConfluentRegistryClient.createClient(restService, maxSchemaObject))
+  }
 }
 
 object ConfluentRegistryClient {
@@ -33,6 +38,10 @@ object ConfluentRegistryClient {
     val maxSchemaObject = settings.getMaxSchemasPerSubject
 
     new CachedSchemaRegistryClient(urls, maxSchemaObject, configs.asJava)
+  }
+
+  private def createClient(restService: RestService, maxSchemaObject: Int) = {
+    new CachedSchemaRegistryClient(restService, maxSchemaObject)
   }
 
 }

--- a/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
+++ b/src/test/scala/za/co/absa/abris/avro/read/confluent/SchemaManagerFactorySpec.scala
@@ -16,11 +16,14 @@
 
 package za.co.absa.abris.avro.read.confluent
 
+import io.confluent.kafka.schemaregistry.client.rest.RestService
+import io.confluent.kafka.schemaregistry.client.security.basicauth.UserInfoCredentialProvider
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import za.co.absa.abris.avro.registry.{AbrisRegistryClient, ConfluentMockRegistryClient, ConfluentRegistryClient, TestRegistryClient}
 import za.co.absa.abris.config.AbrisConfig
 
+import scala.collection.JavaConverters.mapAsJavaMapConverter
 import scala.reflect.runtime.{universe => ru}
 
 class SchemaManagerFactorySpec extends AnyFlatSpec with BeforeAndAfterEach {
@@ -33,6 +36,11 @@ class SchemaManagerFactorySpec extends AnyFlatSpec with BeforeAndAfterEach {
     AbrisConfig.SCHEMA_REGISTRY_URL -> "http://dummy_sr_2",
     AbrisConfig.REGISTRY_CLIENT_CLASS -> "za.co.absa.abris.avro.registry.TestRegistryClient"
   )
+
+  private val restService = new RestService("http://dummy_sr_2")
+  val provider = new UserInfoCredentialProvider()
+  provider.configure(schemaRegistryConfig2.asJava)
+  restService.setBasicAuthCredentialProvider(provider)
 
   override def beforeEach(): Unit = {
     super.beforeEach()


### PR DESCRIPTION
related to issue: https://github.com/AbsaOSS/ABRiS/issues/364

Basic auth doesn't seem to connect to Schema registry on CC using the basic auth method i.e. 
```
AbrisConfig.fromConfluentAvro.downloadReaderSchemaByLatestVersion
          .andTopicNameStrategy(getTopic)
          .usingSchemaRegistry(
            Map(
              AbrisConfig.SCHEMA_REGISTRY_URL -> Configuration.schemaRegistryUrl,
              SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE -> "USER_INFO",
              SchemaRegistryClientConfig.USER_INFO_CONFIG -> s"${Configuration.schemaRegistryUsername}:${Configuration.schemaRegistryPassword}"
            )
          )
```

but able to connect when used with restService constructor of `CachedSchemaRegistryClient`. This PR aims at giving an option to pass `RestService` object to be able to create `CachedSchemaRegistryClient` for it. 